### PR TITLE
Travis ci improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,5 +18,8 @@ addons:
     packages:
     - dotnet-sharedframework-microsoft.netcore.app-1.1.2
 
+before_install:  
+  - if test "$TRAVIS_OS_NAME" == "osx"; then ulimit -n 2048; fi #nuget restore can cause too many open files error
+
 script:
   - ./build.sh --quiet verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then ulimit -n 2048; fi #nuget restore can cause too many open files error
 
 script:
-  - ./build.sh
+  - ./build.sh --quiet verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,14 @@
 language: csharp
+
 mono: none
 dotnet: 2.0.0
+
+osx_image: xcode8.3
 dist: trusty
+
+os:  
+  - linux
+  - osx
 
 addons:
   apt:
@@ -9,8 +16,7 @@ addons:
     - sourceline: 'deb [arch=amd64] https://packages.microsoft.com/repos/microsoft-ubuntu-trusty-prod trusty main'
       key_url: 'https://packages.microsoft.com/keys/microsoft.asc'
     packages:
-    - dotnet-hostfxr-1.0.1
-    - dotnet-sharedframework-microsoft.netcore.app-1.0.5
+    - dotnet-sharedframework-microsoft.netcore.app-1.1.2
 
 script:
   - ./build.sh --quiet verify

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,4 +22,4 @@ before_install:
   - if test "$TRAVIS_OS_NAME" == "osx"; then ulimit -n 2048; fi #nuget restore can cause too many open files error
 
 script:
-  - ./build.sh --quiet verify
+  - ./build.sh

--- a/build.sh
+++ b/build.sh
@@ -9,3 +9,5 @@ fi
 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp2.0;
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;
+
+exit 0

--- a/build.sh
+++ b/build.sh
@@ -1,7 +1,8 @@
 #!/usr/bin/env bash
-dotnet restore
 
-set -e
+set -euo pipefail
+
+dotnet restore
 
 if test "$TRAVIS_OS_NAME" != "osx";
 then 
@@ -11,5 +12,3 @@ fi
 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp2.0;
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;
-
-exit 0

--- a/build.sh
+++ b/build.sh
@@ -9,5 +9,3 @@ fi
 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp2.0;
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;
-
-exit 0

--- a/build.sh
+++ b/build.sh
@@ -7,8 +7,8 @@ dotnet restore
 if test "$TRAVIS_OS_NAME" != "osx";
 then 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp1.1;
-dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp1.1;
+dotnet test test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp1.1;
 fi
 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp2.0;
-dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;
+dotnet test test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;

--- a/build.sh
+++ b/build.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 dotnet restore
 
+set -e
+
 if test "$TRAVIS_OS_NAME" != "osx";
 then 
 dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp1.1;

--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
-dotnet restore && dotnet build -f netcoreapp2.0 -c Release && dotnet test ./test/FastExpressionCompiler.UnitTests && dotnet test ./test/FastExpressionCompiler.IssueTests
+dotnet restore
 
-#dotnet pack ".\src\FastExpressionCompiler" -c Release -o "./dist"
+if test "$TRAVIS_OS_NAME" != "osx";
+then 
+dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp1.1;
+dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp1.1;
+fi
+
+dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj -c Release -f netcoreapp2.0;
+dotnet test test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.UnitTests.csproj -c Release -f netcoreapp2.0;

--- a/src/FastExpressionCompiler/FastExpressionCompiler.csproj
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <VersionPrefix>1.4.0</VersionPrefix>
-    <TargetFrameworks>net45;netstandard1.3;netcoreapp2.0</TargetFrameworks>
+    <TargetFrameworks>net45;netstandard1.3;netstandard2.0</TargetFrameworks>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>FastExpressionCompiler</AssemblyName>

--- a/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
+++ b/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
+++ b/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFrameworks>netcoreapp1.1;netcoreapp2.0</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Hi @dadhi 

I've extended your travis ci config with building on osx and executing with netcoreapp1.1 and netcoreapp2.0 targets simultaneously. 

Unfortunately they are struggling with their macOS builds right now so it might can happen that it won't work for now, hope they'll solve it soon. ([status](https://www.traviscistatus.com/))
Also the addon which is enables the netcoreapp1.1 target execution on a 2.0 env is only available for linux, so only the 2.0 will be executed on OSX.

I also set back the lib's target framework to netstandard2.0 from netcoreapp2.0, i don't know that this change was for a reason or just a try to make the travis build to work, if so i'll set it back again. :)