### PR TITLE
Block support 

### DIFF
--- a/test/FastExpressionCompiler.UnitTests/BlockTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BlockTests.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq.Expressions;
+using System.Reflection;
 using NUnit.Framework;
 using static System.Linq.Expressions.Expression;
 

--- a/test/FastExpressionCompiler.UnitTests/BlockTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BlockTests.cs
@@ -1,0 +1,103 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq.Expressions;
+using NUnit.Framework;
+using static System.Linq.Expressions.Expression;
+
+namespace FastExpressionCompiler.UnitTests
+{
+    [TestFixture]
+    public class BlockTests
+    {
+        [Test]
+        public void Block_local_variable_assignment()
+        {
+            var variable = Variable(typeof(int));
+            var variable2 = Variable(typeof(int));
+
+            var expressions = new List<Expression>
+            {
+                Assign(variable, Constant(5)),
+                Assign(variable2, Constant(6))
+            };
+
+            var block = Block(new[] { variable, variable2 }, expressions);
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(6, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_lambda()
+        {
+            var variable = Variable(typeof(int));
+            var variable2 = Variable(typeof(int));
+
+            var expressions = new List<Expression>
+            {
+                Assign(variable, Constant(5)),
+                Invoke(Lambda(Assign(variable2, Constant(6))))
+            };
+
+            var block = Block(new[] { variable, variable2 }, expressions);
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(6, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_return_with_variable()
+        {
+            var variable = Variable(typeof(int));
+
+            var expressions = new List<Expression>
+            {
+                Assign(variable, Constant(5)),
+                variable
+            };
+
+            var block = Block(new[] { variable }, expressions);
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_member_init()
+        {
+            var variable = Variable(typeof(A));
+
+            var expressions = new List<Expression>
+            {
+                Assign(variable, MemberInit(New(typeof(A).GetConstructor(Type.EmptyTypes)), Bind(typeof(A).GetProperty("K"), Constant(5)))),
+                Property(variable, typeof(A).GetProperty("K"))
+            };
+
+            var block = Block(new[] { variable }, expressions);
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled());
+        }
+
+        private class A
+        {
+            public int K { get; set; }
+        }
+    }
+}

--- a/test/FastExpressionCompiler.UnitTests/BlockTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BlockTests.cs
@@ -1,6 +1,4 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq.Expressions;
 using System.Reflection;
 using NUnit.Framework;
 using static System.Linq.Expressions.Expression;
@@ -15,14 +13,10 @@ namespace FastExpressionCompiler.UnitTests
         {
             var variable = Variable(typeof(int));
             var variable2 = Variable(typeof(int));
-
-            var expressions = new List<Expression>
-            {
-                Assign(variable, Constant(5)),
-                Assign(variable2, Constant(6))
-            };
-
-            var block = Block(new[] { variable, variable2 }, expressions);
+            
+            var block = Block(new[] { variable, variable2 }, 
+                Assign(variable, Constant(5)), 
+                Assign(variable2, Constant(6)));
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -37,14 +31,10 @@ namespace FastExpressionCompiler.UnitTests
         {
             var variable = Variable(typeof(int));
             var variable2 = Variable(typeof(int));
-
-            var expressions = new List<Expression>
-            {
+            
+            var block = Block(new[] { variable, variable2 }, 
                 Assign(variable, Constant(5)),
-                Invoke(Lambda(Assign(variable2, Constant(6))))
-            };
-
-            var block = Block(new[] { variable, variable2 }, expressions);
+                Invoke(Lambda(Assign(variable2, Constant(6)))));
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -55,17 +45,51 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        public void Block_local_variable_assignment_with_lambda_with_param()
+        {
+            var variable = Variable(typeof(int));
+            var variable2 = Variable(typeof(int));
+            var param = Parameter(typeof(int));
+            
+            var block = Block(new[] { variable }, 
+                Assign(variable, Constant(5)),
+                Invoke(Lambda(Block(new[] { variable2 }, 
+                Assign(variable2, param)))));
+
+            var lambda = Lambda<Func<int, int>>(block, param);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int, int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(8, fastCompiled(8));
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_lambda_with_param_override()
+        {
+            var variable = Variable(typeof(int));
+            var param = Parameter(typeof(int));
+            
+            var block = Block(new[] { variable }, 
+                Assign(variable, Constant(5)),
+                Invoke(Lambda(Block(Assign(param, variable)))));
+
+            var lambda = Lambda<Func<int, int>>(block, param);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int, int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled(8));
+        }
+
+        [Test]
         public void Block_local_variable_assignment_return_with_variable()
         {
             var variable = Variable(typeof(int));
-
-            var expressions = new List<Expression>
-            {
+            
+            var block = Block(new[] { variable }, 
                 Assign(variable, Constant(5)),
-                variable
-            };
-
-            var block = Block(new[] { variable }, expressions);
+                variable);
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -79,14 +103,10 @@ namespace FastExpressionCompiler.UnitTests
         public void Block_local_variable_assignment_with_member_init()
         {
             var variable = Variable(typeof(A));
-
-            var expressions = new List<Expression>
-            {
+            
+            var block = Block(new[] { variable }, 
                 Assign(variable, MemberInit(New(typeof(A).GetConstructor(Type.EmptyTypes)), Bind(typeof(A).GetProperty("K"), Constant(5)))),
-                Property(variable, typeof(A).GetProperty("K"))
-            };
-
-            var block = Block(new[] { variable }, expressions);
+                Property(variable, typeof(A).GetProperty("K")));
 
             var lambda = Lambda<Func<int>>(block);
 

--- a/test/FastExpressionCompiler.UnitTests/BlockTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BlockTests.cs
@@ -1,4 +1,7 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Linq.Expressions;
 using System.Reflection;
 using NUnit.Framework;
 using static System.Linq.Expressions.Expression;
@@ -13,10 +16,27 @@ namespace FastExpressionCompiler.UnitTests
         {
             var variable = Variable(typeof(int));
             var variable2 = Variable(typeof(int));
-            
-            var block = Block(new[] { variable, variable2 }, 
-                Assign(variable, Constant(5)), 
+
+            var block = Block(new[] { variable, variable2 },
+                Assign(variable, Constant(5)),
                 Assign(variable2, Constant(6)));
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(6, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_array_closure()
+        {
+            var variables = Vars<int>().Take(20).ToArray();
+
+            var block = Block(new[] { variables[0], variables[1] },
+                Assign(variables[0], Constant(5)),
+                Assign(variables[1], Constant(6)));
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -30,11 +50,27 @@ namespace FastExpressionCompiler.UnitTests
         public void Block_local_variable_assignment_with_lambda()
         {
             var variable = Variable(typeof(int));
-            var variable2 = Variable(typeof(int));
-            
-            var block = Block(new[] { variable, variable2 }, 
+
+            var block = Block(new[] { variable },
                 Assign(variable, Constant(5)),
-                Invoke(Lambda(Assign(variable2, Constant(6)))));
+                Invoke(Lambda(Assign(variable, Constant(6)))));
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(6, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_lambda_array_closure()
+        {
+            var variables = Vars<int>().Take(20).ToArray();
+
+            var block = Block(variables,
+                Assign(variables[0], Constant(5)),
+                Invoke(Lambda(Assign(variables[0], Constant(6)))));
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -50,11 +86,30 @@ namespace FastExpressionCompiler.UnitTests
             var variable = Variable(typeof(int));
             var variable2 = Variable(typeof(int));
             var param = Parameter(typeof(int));
-            
-            var block = Block(new[] { variable }, 
+
+            var block = Block(new[] { variable },
                 Assign(variable, Constant(5)),
-                Invoke(Lambda(Block(new[] { variable2 }, 
+                Invoke(Lambda(Block(new[] { variable2 },
                 Assign(variable2, param)))));
+
+            var lambda = Lambda<Func<int, int>>(block, param);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int, int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(8, fastCompiled(8));
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_lambda_with_param_array_closure()
+        {
+            var variables = Vars<int>().Take(20).ToArray();
+            var param = Parameter(typeof(int));
+
+            var block = Block(new[] { variables[0] },
+                Assign(variables[0], Constant(5)),
+                Invoke(Lambda(Block(new[] { variables[1] },
+                    Assign(variables[1], param)))));
 
             var lambda = Lambda<Func<int, int>>(block, param);
 
@@ -69,10 +124,28 @@ namespace FastExpressionCompiler.UnitTests
         {
             var variable = Variable(typeof(int));
             var param = Parameter(typeof(int));
-            
-            var block = Block(new[] { variable }, 
+
+            var block = Block(new[] { variable },
                 Assign(variable, Constant(5)),
                 Invoke(Lambda(Block(Assign(param, variable)))));
+
+            var lambda = Lambda<Func<int, int>>(block, param);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int, int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled(8));
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_lambda_with_param_override_array_closure()
+        {
+            var variables = Vars<int>().Take(20).ToArray();
+            var param = Parameter(typeof(int));
+
+            var block = Block(new[] { variables[0] },
+                Assign(variables[0], Constant(5)),
+                Invoke(Lambda(Block(Assign(param, variables[0])))));
 
             var lambda = Lambda<Func<int, int>>(block, param);
 
@@ -86,10 +159,27 @@ namespace FastExpressionCompiler.UnitTests
         public void Block_local_variable_assignment_return_with_variable()
         {
             var variable = Variable(typeof(int));
-            
-            var block = Block(new[] { variable }, 
+
+            var block = Block(new[] { variable },
                 Assign(variable, Constant(5)),
                 variable);
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_return_with_variable_array_closure()
+        {
+            var variables = Vars<int>().Take(20).ToArray();
+
+            var block = Block(new[] { variables[0] },
+                Assign(variables[0], Constant(5)),
+                variables[0]);
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -103,10 +193,27 @@ namespace FastExpressionCompiler.UnitTests
         public void Block_local_variable_assignment_with_member_init()
         {
             var variable = Variable(typeof(A));
-            
-            var block = Block(new[] { variable }, 
+
+            var block = Block(new[] { variable },
                 Assign(variable, MemberInit(New(typeof(A).GetConstructor(Type.EmptyTypes)), Bind(typeof(A).GetProperty("K"), Constant(5)))),
                 Property(variable, typeof(A).GetProperty("K")));
+
+            var lambda = Lambda<Func<int>>(block);
+
+            var fastCompiled = ExpressionCompiler.TryCompile<Func<int>>(lambda);
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(5, fastCompiled());
+        }
+
+        [Test]
+        public void Block_local_variable_assignment_with_member_init_array_closure()
+        {
+            var variables = Vars<A>().Take(20).ToArray();
+
+            var block = Block(new[] { variables[0] },
+                Assign(variables[0], MemberInit(New(typeof(A).GetConstructor(Type.EmptyTypes)), Bind(typeof(A).GetProperty("K"), Constant(5)))),
+                Property(variables[0], typeof(A).GetProperty("K")));
 
             var lambda = Lambda<Func<int>>(block);
 
@@ -119,6 +226,12 @@ namespace FastExpressionCompiler.UnitTests
         private class A
         {
             public int K { get; set; }
+        }
+
+        private IEnumerable<ParameterExpression> Vars<T>()
+        {
+            while (true)
+                yield return Variable(typeof(T));
         }
     }
 }


### PR DESCRIPTION
Hi @dadhi 

This is my first version of the block expression support, some further notes:

I reused the concept of the NonPassedParams to store the variables defined by blocks, however currently this violates your rule that the root expression shouldn't contain any, but now if the root is a block and it contains variables then it will.

We can introduce a new structure to store them, but in my opinion it could needlessly increase the complexity of the code, or we can use as it is and update the related comments and maybe rename some related stuffs. 

What do you think? Also about the whole solution :)