### PR TITLE
Expression.IfThen and Expression.Default support

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -401,7 +401,7 @@ namespace FastExpressionCompiler
                     NestedLambdas.GetFirstIndex(it => it.LambdaExpr == info.LambdaExpr) == -1)
                     NestedLambdas = NestedLambdas.WithLast(info);
             }
-            
+
             public object ConstructClosure(bool closureTypeOnly)
             {
                 var constants = Constants;
@@ -991,7 +991,7 @@ namespace FastExpressionCompiler
                         {
                             var nestedNonPassedParam = nestedNonPassedParams[i];
                             if (paramExprs.Count == 0 ||
-                                paramExprs.IndexOf(nestedNonPassedParam) == -1 && 
+                                paramExprs.IndexOf(nestedNonPassedParam) == -1 &&
                                 nestedClosure.DefinedVariables.GetFirstIndex(nestedNonPassedParam) == -1) // if it's a defined variable by the nested lambda then skip
                                 closure.AddNonPassedParam(nestedNonPassedParam);
                         }
@@ -1038,6 +1038,9 @@ namespace FastExpressionCompiler
                         (closure ?? (closure = new ClosureInfo())).AddDefinedVariable(blockExpr.Variables[i]);
 
                     return TryCollectBoundConstants(ref closure, blockExpr.Expressions, paramExprs);
+
+                case ExpressionType.Default:
+                    return true;
 
                 default:
                     if (exprObj is ExpressionInfo)
@@ -1158,6 +1161,10 @@ namespace FastExpressionCompiler
         /// to normal and slow Expression.Compile.</summary>
         private static class EmittingVisitor
         {
+            private static readonly FieldInfo _decimalZero = typeof(decimal).GetTypeInfo().DeclaredFields.First(m => m.IsStatic && m.Name == nameof(decimal.Zero));
+
+            private static readonly FieldInfo _dateTimeMin = typeof(DateTime).GetTypeInfo().DeclaredFields.First(m => m.IsStatic && m.Name == nameof(DateTime.MinValue));
+
             private static readonly MethodInfo _getTypeFromHandleMethod = typeof(Type).GetTypeInfo()
                 .DeclaredMethods.First(m => m.IsStatic && m.Name == "GetTypeFromHandle");
 
@@ -1226,9 +1233,60 @@ namespace FastExpressionCompiler
                     case ExpressionType.Block:
                         return EmitBlock((BlockExpression)exprObj, paramExprs, il, closure);
 
+                    case ExpressionType.Default:
+                        return EmitDefault((DefaultExpression)exprObj, il);
+
                     default:
                         return false;
                 }
+            }
+
+            private static bool EmitDefault(DefaultExpression exprObj, ILGenerator il)
+            {
+                var type = exprObj.Type;
+
+                if (type == typeof(void))
+                    return true;
+                else if (type == typeof(DateTime))
+                    il.Emit(OpCodes.Ldsfld, _dateTimeMin);
+                else if (type == typeof(object))
+                {
+                    if (type.GetTypeInfo().IsValueType)
+                    {
+                        LocalBuilder lb = il.DeclareLocal(type);
+                        il.Emit(OpCodes.Ldloca, lb);
+                        il.Emit(OpCodes.Initobj, type);
+                        il.Emit(OpCodes.Ldloc, lb);
+                    }
+                    else
+                        il.Emit(OpCodes.Ldnull);
+                }
+                else if (type == typeof(string))
+                    il.Emit(OpCodes.Ldnull);
+                else if (type == typeof(bool) ||
+                        type == typeof(byte) ||
+                        type == typeof(sbyte) ||
+                        type == typeof(int) ||
+                        type == typeof(uint) ||
+                        type == typeof(short) ||
+                        type == typeof(ushort))
+                    il.Emit(OpCodes.Ldc_I4_0);
+                else if (type == typeof(long) ||
+                        type == typeof(ulong))
+                {
+                    il.Emit(OpCodes.Ldc_I4_0);
+                    il.Emit(OpCodes.Conv_I8);
+                }
+                else if (type == typeof(float))
+                    il.Emit(OpCodes.Ldc_R4, default(float));
+                else if (type == typeof(double))
+                    il.Emit(OpCodes.Ldc_R8, default(double));
+                else if (type == typeof(decimal))
+                    il.Emit(OpCodes.Ldsfld, _decimalZero);
+                else
+                    return false;
+
+                return true;
             }
 
             private static bool EmitBlock(BlockExpression exprObj, IList<ParameterExpression> paramExprs, ILGenerator il, ClosureInfo closure)
@@ -1783,8 +1841,8 @@ namespace FastExpressionCompiler
                 // if this assignment is part of a single bodyless expression or the result of a block
                 // we should put it's result to the evaluation stack before the return, otherwise we are
                 // somewhere inside the block, so we shouldn't return with the result
-                var shouldPushResult = closure == null 
-                    || closure.OpenedBlocks.IsEmpty 
+                var shouldPushResult = closure == null
+                    || closure.OpenedBlocks.IsEmpty
                     || closure.OpenedBlocks.Head.Result == exprObj;
 
                 switch (leftNodeType)
@@ -2111,7 +2169,7 @@ namespace FastExpressionCompiler
                 for (var nestedParamIndex = 0; nestedParamIndex < nestedNonPassedParams.Length; nestedParamIndex++)
                 {
                     var nestedUsedParam = nestedNonPassedParams[nestedParamIndex];
-                    
+
                     // Duplicate nested array on stack to store the item, and load index to where to store
                     if (isNestedArrayClosure)
                     {
@@ -2519,8 +2577,8 @@ namespace FastExpressionCompiler
         public static T GetFirst<T>(this IEnumerable<T> source)
         {
             var arr = source as T[];
-            return arr == null 
-                ? source.FirstOrDefault() 
+            return arr == null
+                ? source.FirstOrDefault()
                 : arr.Length != 0 ? arr[0] : default(T);
         }
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1161,10 +1161,6 @@ namespace FastExpressionCompiler
         /// to normal and slow Expression.Compile.</summary>
         private static class EmittingVisitor
         {
-            private static readonly FieldInfo _decimalZero = typeof(decimal).GetTypeInfo().DeclaredFields.First(m => m.IsStatic && m.Name == nameof(decimal.Zero));
-
-            private static readonly FieldInfo _dateTimeMin = typeof(DateTime).GetTypeInfo().DeclaredFields.First(m => m.IsStatic && m.Name == nameof(DateTime.MinValue));
-
             private static readonly MethodInfo _getTypeFromHandleMethod = typeof(Type).GetTypeInfo()
                 .DeclaredMethods.First(m => m.IsStatic && m.Name == "GetTypeFromHandle");
 
@@ -1247,24 +1243,11 @@ namespace FastExpressionCompiler
 
                 if (type == typeof(void))
                     return true;
-                else if (type == typeof(DateTime))
-                    il.Emit(OpCodes.Ldsfld, _dateTimeMin);
-                else if (type == typeof(object))
-                {
-                    if (type.GetTypeInfo().IsValueType)
-                    {
-                        LocalBuilder lb = il.DeclareLocal(type);
-                        il.Emit(OpCodes.Ldloca, lb);
-                        il.Emit(OpCodes.Initobj, type);
-                        il.Emit(OpCodes.Ldloc, lb);
-                    }
-                    else
-                        il.Emit(OpCodes.Ldnull);
-                }
                 else if (type == typeof(string))
                     il.Emit(OpCodes.Ldnull);
                 else if (type == typeof(bool) ||
                         type == typeof(byte) ||
+                        type == typeof(char) ||
                         type == typeof(sbyte) ||
                         type == typeof(int) ||
                         type == typeof(uint) ||
@@ -1281,10 +1264,15 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Ldc_R4, default(float));
                 else if (type == typeof(double))
                     il.Emit(OpCodes.Ldc_R8, default(double));
-                else if (type == typeof(decimal))
-                    il.Emit(OpCodes.Ldsfld, _decimalZero);
+                else if (type.GetTypeInfo().IsValueType)
+                {
+                    LocalBuilder lb = il.DeclareLocal(type);
+                    il.Emit(OpCodes.Ldloca, lb);
+                    il.Emit(OpCodes.Initobj, type);
+                    il.Emit(OpCodes.Ldloc, lb);
+                }
                 else
-                    return false;
+                    il.Emit(OpCodes.Ldnull);
 
                 return true;
             }

--- a/test/FastExpressionCompiler.UnitTests/ConditionalOperatorsTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/ConditionalOperatorsTests.cs
@@ -168,7 +168,7 @@ namespace FastExpressionCompiler.UnitTests
         public static void WriteLine(string s) => Console.WriteLine(s);
 
         [Test]
-        public void Test_IfThen()
+        public void IfThen_with_block()
         {
             var variable = Variable(typeof(int));
             var param = Parameter(typeof(bool));
@@ -189,7 +189,7 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
-        public void Test_IfThenElse_WithParam()
+        public void IfThenElse_with_block()
         {
             var variable = Variable(typeof(int));
             var param = Parameter(typeof(bool));

--- a/test/FastExpressionCompiler.UnitTests/DefaultTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/DefaultTests.cs
@@ -1,0 +1,60 @@
+﻿using NUnit.Framework;
+using System;
+using static System.Linq.Expressions.Expression;
+
+namespace FastExpressionCompiler.UnitTests
+{
+    [TestFixture]
+    public class DefaultTests
+    {
+        [Test]
+        [TestCase(typeof(int), default(int))]
+        [TestCase(typeof(bool), default(bool))]
+        [TestCase(typeof(byte), default(byte))]
+        [TestCase(typeof(char), default(char))]
+        [TestCase(typeof(ushort), default(ushort))]
+        [TestCase(typeof(uint), default(uint))]
+        [TestCase(typeof(ulong), default(ulong))]
+        [TestCase(typeof(sbyte), default(sbyte))]
+        [TestCase(typeof(short), default(short))]
+        [TestCase(typeof(long), default(long))]
+        [TestCase(typeof(string), default(string))]
+        [TestCase(typeof(float), default(float))]
+        [TestCase(typeof(double), default(double))]
+        [TestCase(typeof(object), default(object))]
+        public void Can_compile_default_values(Type type, object expectedResult)
+        {
+            var dlgt = Lambda<Func<object>>(Convert(Default(type), typeof(object))).CompileFast(true);
+
+            Assert.IsNotNull(dlgt);
+            Assert.AreEqual(expectedResult, dlgt());
+        }
+
+        [Test]
+        public void Can_compile_default_decimal_value()
+        {
+            var dlgt = Lambda<Func<decimal>>(Default(typeof(decimal))).CompileFast(true);
+
+            Assert.IsNotNull(dlgt);
+            Assert.AreEqual(default(decimal), dlgt());
+        }
+
+        [Test]
+        public void Can_compile_default_datetime_value()
+        {
+            var dlgt = Lambda<Func<DateTime>>(Default(typeof(DateTime))).CompileFast(true);
+
+            Assert.IsNotNull(dlgt);
+            Assert.AreEqual(default(DateTime), dlgt());
+        }
+
+        [Test]
+        public void Can_compile_default_timespan_value()
+        {
+            var dlgt = Lambda<Func<TimeSpan>>(Default(typeof(TimeSpan))).CompileFast(true);
+
+            Assert.IsNotNull(dlgt);
+            Assert.AreEqual(default(TimeSpan), dlgt());
+        }
+    }
+}


### PR DESCRIPTION
Hi @dadhi 

In this PR i added support to the IfThen expression type (#32), related to that i also implemented the Default expressions, which was necessary because the ifFalse member of the IfThen expression is a Default(typeof(void)).

GotoExpressions like Return are not implemented yet.