### PR TITLE
Refactor the handling of block variables

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -512,7 +512,7 @@ namespace FastExpressionCompiler
                 this.openedBlockVariables = this.openedBlockVariables.Tail ?? Tools.Stack<KeyValuePair<ParameterExpression, LocalBuilder>[]>.Empty;
             }
 
-            public LocalBuilder GetLocalVariableOrDefault(object variable)
+            public LocalBuilder GetLocalVariableOrDefault(object variableExpr)
             {
                 if (this.openedBlockVariables.IsEmpty)
                     return null;
@@ -523,7 +523,7 @@ namespace FastExpressionCompiler
                     var length = current.Head.Length;
                     for (var i = 0; i < length; i++)
                     {
-                        if (current.Head[i].Key == variable)
+                        if (current.Head[i].Key == variableExpr)
                             return current.Head[i].Value;
                     }
 
@@ -533,7 +533,7 @@ namespace FastExpressionCompiler
                 return null;
             }
 
-            public bool CurrentBlockContainsVariable(ParameterExpression parameterExpression)
+            public bool IsDefinedVariable(ParameterExpression parameterExpression)
             {
                 if (this.OpenedBlocks.IsEmpty)
                     return false;
@@ -916,7 +916,7 @@ namespace FastExpressionCompiler
                     // it means parameter is provided by outer lambda and should be put in closure for current lambda
                     var exprInfo = exprObj as ParameterExpressionInfo;
                     var paramExpr = exprInfo ?? (ParameterExpression)exprObj;
-                    if (paramExprs.IndexOf(paramExpr) == -1 || closure != null && !closure.CurrentBlockContainsVariable(paramExpr))
+                    if (paramExprs.IndexOf(paramExpr) == -1 || closure != null && !closure.IsDefinedVariable(paramExpr))
                         (closure ?? (closure = new ClosureInfo())).AddNonPassedParam(paramExpr);
                     return true;
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -260,7 +260,7 @@ namespace FastExpressionCompiler
             if (!TryCollectBoundConstants(ref closureInfo, exprObj, exprNodeType, exprType, paramExprs))
                 return null;
 
-            if (closureInfo == null || !closureInfo.HasClosureArgument)
+            if (closureInfo == null || !closureInfo.HasBoundClosure)
                 return TryCompileStaticDelegate(delegateType, paramTypes, returnType, exprObj, exprNodeType, exprType, paramExprs);
 
             var closureObject = closureInfo.ConstructClosure(closureTypeOnly: isNestedLambda);
@@ -364,7 +364,7 @@ namespace FastExpressionCompiler
 
             // Tells that we should construct a bounded closure object for the compiled delegate,
             // also indicates that we have to shift when we are operating on arguments becouse the first will be the closure
-            public bool HasClosureArgument => this.Constants.Length > 0 || this.NestedLambdas.Length > 0 || this.NonPassedParameters.Length > 0;
+            public bool HasBoundClosure => this.Constants.Length > 0 || this.NestedLambdas.Length > 0 || this.NonPassedParameters.Length > 0;
 
             public void AddConstant(object expr, object value, Type type)
             {
@@ -1526,7 +1526,7 @@ namespace FastExpressionCompiler
                 // if parameter is passed, then just load it on stack
                 if (paramIndex != -1)
                 {
-                    if (closure != null && closure.HasClosureArgument)
+                    if (closure != null && closure.HasBoundClosure)
                         paramIndex += 1; // shift parameter indices by one, because the first one will be closure
                     LoadParamArg(il, paramIndex);
                     return true;
@@ -1767,7 +1767,7 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Ldtoken, (Type)constantValue);
                     il.Emit(OpCodes.Call, _getTypeFromHandleMethod);
                 }
-                else if (closure != null && closure.HasClosureArgument)
+                else if (closure != null && closure.HasBoundClosure)
                 {
                     var constantIndex = closure.Constants.GetFirstIndex(it => it.ConstantExpr == exprObj);
                     if (constantIndex == -1)
@@ -2102,7 +2102,7 @@ namespace FastExpressionCompiler
                         var paramIndex = paramExprs.GetFirstIndex(left);
                         if (paramIndex != -1)
                         {
-                            if (closure != null && closure.HasClosureArgument)
+                            if (closure != null && closure.HasBoundClosure)
                                 paramIndex += 1; // shift parameter indices by one, because the first one will be closure
 
                             if (paramIndex >= byte.MaxValue)


### PR DESCRIPTION
Hi @dadhi 

Here is the PR about the new way of handling the variables of the block expressions. I agree that the `ClosureInfo` behaves more like a context passed through the emitter methods, especially now when i introduced a flag which supposed to determine that a given DynamicMethod should bound to a closure object or not, because only the `ClosureInfo`s non-nullness is not an exact indicator of this anymore. 

However i didn't do the renaming now, it's your privilege i think. :)