### PR TITLE
intermediate add ref support

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -3277,7 +3277,7 @@ namespace FastExpressionCompiler
         /// <summary>Analog of Expression.Parameter</summary>
         /// <remarks>For now it is return just an `Expression.Parameter`</remarks>
         public static ParameterExpressionInfo Parameter(Type type, string name = null) =>
-            new ParameterExpressionInfo(type, name, false);
+            new ParameterExpressionInfo(type, name, false); // TODO: #46
 
         /// <summary>Analog of Expression.Constant</summary>
         public static ConstantExpressionInfo Constant(object value, Type type = null) =>

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -1,7 +1,9 @@
-﻿using BenchmarkDotNet.Running;
+﻿using System;
+using BenchmarkDotNet.Running;
 
 namespace FastExpressionCompiler.Benchmarks
 {
+    
     public class Program
     {
         public static void Main()
@@ -11,8 +13,9 @@ namespace FastExpressionCompiler.Benchmarks
 
             //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_Compile>();
             //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_Execute>();
-            BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_ExecuteAsync>();
-
+            //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_ExecuteAsync>();
+            BenchmarkRunner.Run<StaticTypeOf>();
+            
             //BenchmarkRunner.Run<ExprInfoVsExpr_TryCatchExpr.Compilation>();
             //BenchmarkRunner.Run<ExprInfoVsExpr_TryCatchExpr.Invocation>();
 

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -13,9 +13,9 @@ namespace FastExpressionCompiler.Benchmarks
 
             //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_Compile>();
             //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_Execute>();
-            //BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_ExecuteAsync>();
-            BenchmarkRunner.Run<StaticTypeOf>();
-            
+            BenchmarkRunner.Run<ObjectExecutor_AsyncMethod_ExecuteAsync>();
+            //BenchmarkRunner.Run<StaticTypeOfSwitch>();
+        
             //BenchmarkRunner.Run<ExprInfoVsExpr_TryCatchExpr.Compilation>();
             //BenchmarkRunner.Run<ExprInfoVsExpr_TryCatchExpr.Invocation>();
 

--- a/test/FastExpressionCompiler.Benchmarks/StaticTypeOf.cs
+++ b/test/FastExpressionCompiler.Benchmarks/StaticTypeOf.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Reflection.Emit;
+using BenchmarkDotNet.Attributes;
+
+namespace FastExpressionCompiler.Benchmarks
+{
+
+    [CoreJob, ClrJob]
+    [MemoryDiagnoser]
+    public class StaticTypeOf
+    {
+        private static OpCode OpCodeForTypeByTypeOf(Type type)
+        {
+            if (type == typeof(int))
+                return OpCodes.Stind_I4;
+            else if (type == typeof(byte))
+                return OpCodes.Stind_I1;
+            else if (type == typeof(short))
+                return OpCodes.Stind_I2;
+            else if (type == typeof(long))
+                return OpCodes.Stind_I8;
+            else if (type == typeof(float))
+                return OpCodes.Stind_R4;
+            else
+                throw new NotImplementedException();
+        }
+
+        private static  Type intT = typeof(int);
+        private static  Type byteT = typeof(byte);
+        private static  Type shortT = typeof(short);
+        private static  Type longT = typeof(long);
+        private static Type floatT = typeof(float);
+
+        private static OpCode OpCodeForTypeByStatitcType(Type type)
+        {
+            if (type == intT)
+                return OpCodes.Stind_I4;
+            else if (type == byteT)
+                return OpCodes.Stind_I1;
+            else if (type == shortT)
+                return OpCodes.Stind_I2;
+            else if (type == longT)
+                return OpCodes.Stind_I8;
+            else if (type == floatT)
+                return OpCodes.Stind_R4;
+            else
+                throw new NotImplementedException();
+        }
+
+        [Benchmark(Baseline = true)]
+        public object OpCodeForTypeByTypeOfTest() => OpCodeForTypeByTypeOf(floatT);
+
+        [Benchmark]
+        public object OpCodeForTypeByStatitcTypeTest() => OpCodeForTypeByStatitcType(floatT);
+    }
+}

--- a/test/FastExpressionCompiler.Benchmarks/StaticTypeOfSwitch.cs
+++ b/test/FastExpressionCompiler.Benchmarks/StaticTypeOfSwitch.cs
@@ -7,7 +7,7 @@ namespace FastExpressionCompiler.Benchmarks
 
     [CoreJob, ClrJob]
     [MemoryDiagnoser]
-    public class StaticTypeOf
+    public class StaticTypeOfSwitch
     {
         private static OpCode OpCodeForTypeByTypeOf(Type type)
         {
@@ -25,11 +25,11 @@ namespace FastExpressionCompiler.Benchmarks
                 throw new NotImplementedException();
         }
 
-        private static  Type intT = typeof(int);
-        private static  Type byteT = typeof(byte);
-        private static  Type shortT = typeof(short);
-        private static  Type longT = typeof(long);
-        private static Type floatT = typeof(float);
+        private readonly static Type intT = typeof(int);
+        private readonly static Type byteT = typeof(byte);
+        private readonly static Type shortT = typeof(short);
+        private readonly static Type longT = typeof(long);
+        private readonly static Type floatT = typeof(float);
 
         private static OpCode OpCodeForTypeByStatitcType(Type type)
         {

--- a/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
+++ b/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
@@ -2,6 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
+++ b/test/FastExpressionCompiler.IssueTests/FastExpressionCompiler.IssueTests.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <TargetFrameworks>net46;netcoreapp2.0</TargetFrameworks>
-    <LangVersion>7.3</LangVersion>
+    <LangVersion>7.1</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">

--- a/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
@@ -1,40 +1,146 @@
-﻿using System.Linq.Expressions;
+﻿using System;
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
 using NUnit.Framework;
+using System.Collections.Generic;
 
 namespace FastExpressionCompiler.IssueTests
 {
     [TestFixture]
     public class Issue55_CompileFast_crash_with_ref_parameter
     {
-        public delegate void Setter(ref int obj);
+        delegate void VoidReturnByRefIntIn(ref int obj);
+        delegate int IntRetrunByRefIntInt(ref int it);
+        delegate void VoidReturnByRefIntAndOtherIntIn(ref int obj, int val);
+        delegate void VoidReturnByRefTAndOtherIntIn<T>(ref T obj, int value);
+        struct StructWithIntField { public int IntField; }
+        delegate void VoidReturnByRefStructWithIntFieldAndIntIn(ref StructWithIntField obj, int value);
+
+
 
         [Test]
         public void RefDoNothingShouldNoCrash()
         {
-            var objRef = Expression.Parameter(typeof(int).MakeByRefType());
-            var body = Expression.Empty();
-            var lambda = Expression.Lambda<Setter>(body, objRef);
+            void DoNothing(ref int igonre) { };
+            var lambda = Lambda<VoidReturnByRefIntIn>(Empty(), Parameter(typeof(int).MakeByRefType()));
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA);
             Assert.AreEqual(0, exampleA);
 
-            var compiledB = lambda.CompileFast<Setter>(true);
+            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
             var exampleB = default(int);
             compiledB(ref exampleB);
             Assert.AreEqual(0, exampleB);
+
+            VoidReturnByRefIntIn direct = DoNothing;
+            var exampleC = default(int);
+            direct(ref exampleC);
+            Assert.AreEqual(0, exampleC);
         }
+
+        [Test]
+        public void RefFromConstant()
+        {
+            void SetSmallConstant(ref int localByRef)
+            {
+                const int objVal = 3;
+                localByRef = objVal;
+            }
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var lambda = Lambda<VoidReturnByRefIntIn>(Assign(objRef, Constant(7)), objRef);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(int);
+            compiledA(ref exampleA);
+            Assert.AreEqual(3, exampleA);
+
+            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
+            var exampleB = default(int);
+            compiledB(ref exampleB);
+            Assert.AreEqual(3, exampleB);
+
+            VoidReturnByRefIntIn direct = SetSmallConstant;
+            var exampleC = default(int);
+            direct(ref exampleC);
+            Assert.AreEqual(3, exampleC);
+        }
+
+        [Test]
+        //[Ignore("Fails on IsNotNull")]
+        public void ConstanRetrunIsSupported()
+        {
+            var varr = Variable(typeof(int), "xxx");
+            var assign = Assign(varr, Constant(7));
+            var lambda = Lambda<Func<int>>(Block(new List<ParameterExpression> { varr }, assign, Label(Label(typeof(int)), varr)));
+            var compiled = lambda.Compile();
+            var value1 = compiled();
+            Assert.AreEqual(7, value1);
+            var fastCompiled = lambda.CompileFast<Func<int>>(true);
+            Assert.IsNotNull(fastCompiled);
+        }
+
+        [Test]
+        public void RefFromConst21ant()
+        {
+
+
+            int SetSmallConstant(ref int localByRef) => default(int);
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var ret = Block(Label(Label(typeof(int)), Constant(default(int))));
+            var lambda = Lambda<IntRetrunByRefIntInt>(ret, objRef);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(int);
+            Assert.AreEqual(0, compiledA(ref exampleA));
+            Assert.AreEqual(0, exampleA);
+
+            var compiledB = lambda.CompileFast<IntRetrunByRefIntInt>(true);
+            var exampleB = default(int);
+            Assert.AreEqual(0, compiledB(ref exampleB));
+            Assert.AreEqual(0, exampleB);
+
+            IntRetrunByRefIntInt direct = SetSmallConstant;
+            var exampleC = default(int);
+            Assert.AreEqual(0, direct(ref exampleC));
+            Assert.AreEqual(0, exampleC);
+        }
+
+        [Test]
+        public void RefFromLargeConstant()
+        {
+            void SetSmallConstant(ref int localByRef)
+            {
+                const int objVal = 42_123_666;
+                localByRef = objVal;
+            }
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var lambda = Lambda<VoidReturnByRefIntIn>(Assign(objRef, Constant(42_123_666)), objRef);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(int);
+            compiledA(ref exampleA);
+            Assert.AreEqual(42_123_666, exampleA);
+
+            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
+            var exampleB = default(int);
+            compiledB(ref exampleB);
+            Assert.AreEqual(42_123_666, exampleB);
+
+            VoidReturnByRefIntIn direct = SetSmallConstant;
+            var exampleC = default(int);
+            direct(ref exampleC);
+            Assert.AreEqual(42_123_666, exampleC);
+        }
+
+
 
         // will retain next methods under well defined names
         // 1. newcomvers may look into il
         // 2. may call thes for test comparison
         // 3. as documentation of what is covered
-        private void Set7Constant(ref int objRef)
-        {
-            const int objVal = 7; 
-            objRef = objVal;
-        }
+
 
         private void Set1124144112Constant(ref int objRef)
         {
@@ -61,7 +167,7 @@ namespace FastExpressionCompiler.IssueTests
             return read;
         }
 
-        private void ReadIntoVassr( int objRef)
+        private void ReadIntoVassr(int objRef)
         {
             var x = 0;
         }
@@ -72,84 +178,64 @@ namespace FastExpressionCompiler.IssueTests
             return x;
         }
 
-        [Test]
-        public void RefFromConstant()
-        {
-            var objRef = Expression.Parameter(typeof(int).MakeByRefType());
-            var objVal = Expression.Constant(7);
-            var body = Expression.Assign(objRef, objVal);
-            var lambda = Expression.Lambda<Setter>(body, objRef);
 
-            var compiledA = lambda.Compile();
-            var exampleA = default(int);
-            compiledA(ref exampleA);
-            Assert.AreEqual(7, exampleA);
 
-            var compiledB = lambda.CompileFast<Setter>(true);
-            var exampleB = default(int);
-            compiledB(ref exampleB);
-            Assert.AreEqual(7, exampleB);
-        }
-
-        public delegate void Setter2(ref int obj, int val);
 
         [Test]
         public void RefSetFromParameter()
         {
-            var objRef = Expression.Parameter(typeof(int).MakeByRefType());
-            var objVal = Expression.Parameter(typeof(int));
-            var body = Expression.Assign(objRef, objVal);
-            var lambda = Expression.Lambda<Setter2>(body, objRef, objVal);
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var objVal = Parameter(typeof(int));
+            var body = Assign(objRef, objVal);
+            var lambda = Lambda<VoidReturnByRefIntAndOtherIntIn>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA, 7);
             Assert.AreEqual(7, exampleA);
 
-            var compiledB = lambda.CompileFast<Setter2>(true);
+            var compiledB = lambda.CompileFast<VoidReturnByRefIntAndOtherIntIn>(true);
             var exampleB = default(int);
             compiledB(ref exampleB, 7);
             Assert.AreEqual(7, exampleB);
         }
 
-        delegate void NonGenericFieldSetter(ref Bla obj, int value);
-        
+
+
         [Test]
         public void NonGenericSetterFieldShould_not_crash()
         {
-            var objRef = Expression.Parameter(typeof(Bla).MakeByRefType());
-            var objVal = Expression.Parameter(typeof(int));
-            var prop = Expression.PropertyOrField(objRef, nameof(Bla.Hmm));
-            var body = Expression.Assign(prop, objVal);
-            var lambda = Expression.Lambda<NonGenericFieldSetter>(body, objRef, objVal);
+            var objRef = Parameter(typeof(StructWithIntField).MakeByRefType());
+            var objVal = Parameter(typeof(int));
+            var prop = PropertyOrField(objRef, nameof(StructWithIntField.IntField));
+            var body = Assign(prop, objVal);
+            var lambda = Lambda<VoidReturnByRefStructWithIntFieldAndIntIn>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
-            var exampleA = default(Bla);
+            var exampleA = default(StructWithIntField);
             compiledA(ref exampleA, 7);
-            Assert.AreEqual(7, exampleA.Hmm);
+            Assert.AreEqual(7, exampleA.IntField);
 
-            var compiledB = lambda.CompileFast<NonGenericFieldSetter>(true);
+            var compiledB = lambda.CompileFast<VoidReturnByRefStructWithIntFieldAndIntIn>(true);
             Assert.IsNull(compiledB);
         }
 
-        public struct Bla { public int Hmm; }
-        public delegate void GenericSetter<T>(ref T obj, int value);
 
         [Test]
         public void GenericRefStructFieldShould_not_crash()
         {
-            var objRef = Expression.Parameter(typeof(Bla).MakeByRefType());
-            var objVal = Expression.Parameter(typeof(int));
-            var prop = Expression.PropertyOrField(objRef, nameof(Bla.Hmm));
-            var body = Expression.Assign(prop, objVal);
-            var lambda = Expression.Lambda<GenericSetter<Bla>>(body, objRef, objVal);
+            var objRef = Parameter(typeof(StructWithIntField).MakeByRefType());
+            var objVal = Parameter(typeof(int));
+            var prop = PropertyOrField(objRef, nameof(StructWithIntField.IntField));
+            var body = Assign(prop, objVal);
+            var lambda = Lambda<VoidReturnByRefTAndOtherIntIn<StructWithIntField>>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
-            var exampleA = default(Bla);
+            var exampleA = default(StructWithIntField);
             compiledA(ref exampleA, 7);
-            Assert.AreEqual(7, exampleA.Hmm);
+            Assert.AreEqual(7, exampleA.IntField);
 
-            var compiledB = lambda.CompileFast<GenericSetter<Bla>>(true);
+            var compiledB = lambda.CompileFast<VoidReturnByRefTAndOtherIntIn<StructWithIntField>>(true);
             Assert.IsNull(compiledB);
         }
     }

--- a/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
@@ -26,8 +26,53 @@ namespace FastExpressionCompiler.IssueTests
             Assert.AreEqual(0, exampleB);
         }
 
-        //[Test]
-        [Ignore("Fails, but should fix")]
+        // will retain next methods under well defined names
+        // 1. newcomvers may look into il
+        // 2. may call thes for test comparison
+        // 3. as documentation of what is covered
+        private void Set7Constant(ref int objRef)
+        {
+            const int objVal = 7; 
+            objRef = objVal;
+        }
+
+        private void Set1124144112Constant(ref int objRef)
+        {
+            const int objVal = 1124144112;
+            objRef = objVal;
+        }
+
+        private static void SetXXXXXConstant(ref int objRef)
+        {
+            const int objVal = 1124144112;
+            objRef = objVal;
+        }
+
+        private void Set1124144112Constant(ref int objRef, ref int objRef2)
+        {
+            const int objVal = 1124144112;
+            objRef = objVal;
+            objRef2 = 7;
+        }
+
+        private int ReadIntoVar(ref int objRef)
+        {
+            var read = objRef;
+            return read;
+        }
+
+        private void ReadIntoVassr( int objRef)
+        {
+            var x = 0;
+        }
+
+        private int ReadIntoVas131231231312sr(int objRef)
+        {
+            var x = objRef;
+            return x;
+        }
+
+        [Test]
         public void RefFromConstant()
         {
             var objRef = Expression.Parameter(typeof(int).MakeByRefType());
@@ -48,8 +93,7 @@ namespace FastExpressionCompiler.IssueTests
 
         public delegate void Setter2(ref int obj, int val);
 
-        //[Test]
-        [Ignore("Fails, but should fix")]
+        [Test]
         public void RefSetFromParameter()
         {
             var objRef = Expression.Parameter(typeof(int).MakeByRefType());

--- a/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
@@ -9,32 +9,31 @@ namespace FastExpressionCompiler.IssueTests
     [TestFixture]
     public class Issue55_CompileFast_crash_with_ref_parameter
     {
-        delegate void VoidReturnByRefIntIn(ref int obj);
-        delegate int IntRetrunByRefIntInt(ref int it);
-        delegate void VoidReturnByRefIntAndOtherIntIn(ref int obj, int val);
-        delegate void VoidReturnByRefTAndOtherIntIn<T>(ref T obj, int value);
+        delegate TResult FuncRef<T, out TResult>(ref T a1);
+        delegate TResult FuncRefIn<T1, in T2, out TResult>(ref T1 a1, T2 a2);
+        delegate void ActionRef<T>(ref T a1);
+        delegate void ActionRefIn<T1, in T2>(ref T1 obj, T2 value);
+        delegate void ActionRefRef<T1, T2>(ref T1 obj, ref T2 value);
+
         struct StructWithIntField { public int IntField; }
-        delegate void VoidReturnByRefStructWithIntFieldAndIntIn(ref StructWithIntField obj, int value);
-
-
 
         [Test]
         public void RefDoNothingShouldNoCrash()
         {
             void DoNothing(ref int igonre) { };
-            var lambda = Lambda<VoidReturnByRefIntIn>(Empty(), Parameter(typeof(int).MakeByRefType()));
+            var lambda = Lambda<ActionRef<int>>(Empty(), Parameter(typeof(int).MakeByRefType()));
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA);
             Assert.AreEqual(0, exampleA);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
+            var compiledB = lambda.CompileFast<ActionRef<int>>(true);
             var exampleB = default(int);
             compiledB(ref exampleB);
             Assert.AreEqual(0, exampleB);
 
-            VoidReturnByRefIntIn direct = DoNothing;
+            ActionRef<int> direct = DoNothing;
             var exampleC = default(int);
             direct(ref exampleC);
             Assert.AreEqual(0, exampleC);
@@ -49,59 +48,182 @@ namespace FastExpressionCompiler.IssueTests
                 localByRef = objVal;
             }
             var objRef = Parameter(typeof(int).MakeByRefType());
-            var lambda = Lambda<VoidReturnByRefIntIn>(Assign(objRef, Constant(7)), objRef);
+            var lambda = Lambda<ActionRef<int>>(Assign(objRef, Constant(3)), objRef);
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA);
             Assert.AreEqual(3, exampleA);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
+            var compiledB = lambda.CompileFast<ActionRef<int>>(true);
             var exampleB = default(int);
             compiledB(ref exampleB);
             Assert.AreEqual(3, exampleB);
 
-            VoidReturnByRefIntIn direct = SetSmallConstant;
+            ActionRef<int> direct = SetSmallConstant;
             var exampleC = default(int);
             direct(ref exampleC);
             Assert.AreEqual(3, exampleC);
         }
 
         [Test]
-        //[Ignore("Fails on IsNotNull")]
-        public void ConstanRetrunIsSupported()
+        public void GenericRefFromConstant()
         {
-            var varr = Variable(typeof(int), "xxx");
-            var assign = Assign(varr, Constant(7));
-            var lambda = Lambda<Func<int>>(Block(new List<ParameterExpression> { varr }, assign, Label(Label(typeof(int)), varr)));
-            var compiled = lambda.Compile();
-            var value1 = compiled();
-            Assert.AreEqual(7, value1);
-            var fastCompiled = lambda.CompileFast<Func<int>>(true);
-            Assert.IsNotNull(fastCompiled);
+            void SetSmallConstant(ref byte localByRef)
+            {
+                const byte objVal = 3;
+                localByRef = objVal;
+            }
+            var objRef = Parameter(typeof(byte).MakeByRefType());
+            var lambda = Lambda<ActionRef<byte>>(Assign(objRef, Constant((byte)3)), objRef);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(byte);
+            compiledA(ref exampleA);
+            Assert.AreEqual(3, exampleA);
+
+            var compiledB = lambda.CompileFast<ActionRef<byte>>(true);
+            var exampleB = default(byte);
+            compiledB(ref exampleB);
+            Assert.AreEqual(3, exampleB);
+
+            ActionRef<byte> direct = SetSmallConstant;
+            var exampleC = default(byte);
+            direct(ref exampleC);
+            Assert.AreEqual(3, exampleC);
         }
 
         [Test]
-        public void RefFromConst21ant()
+        public void GenericRefFromConstantReturn()
         {
+            ushort SetSmallConstant(ref uint localByRef)
+            {
+                localByRef = 3;
+                return 7;
+            }
+            var objRef = Parameter(typeof(uint).MakeByRefType());
+            var lambda = Lambda<FuncRef<uint, ushort>>(Block(Assign(objRef, Constant((uint)3)), Constant((ushort)7)), objRef);
 
+            var compiledA = lambda.Compile();
+            var exampleA = default(uint);
+            Assert.AreEqual(7, compiledA(ref exampleA));
+            Assert.AreEqual(3, exampleA);
 
-            int SetSmallConstant(ref int localByRef) => default(int);
+            var compiledB = lambda.CompileFast<FuncRef<uint, ushort>>(true);
+            var exampleB = default(uint);
+            Assert.AreEqual(7, compiledB(ref exampleB));
+            Assert.AreEqual(3, exampleB);
+
+            FuncRef<uint, ushort> direct = SetSmallConstant;
+            var exampleC = default(uint);
+            Assert.AreEqual(7, direct(ref exampleC));
+            Assert.AreEqual(3, exampleC);
+        }
+
+        [Test]
+        public void RefReturnToVoid()
+        {
+            ushort SetSmallConstant(ref uint localByRef)
+            {
+                localByRef = 3;
+                return 7;
+            }
+            var objRef = Parameter(typeof(uint).MakeByRefType());
+            var lambda = Lambda<ActionRef<uint>>(Block(Assign(objRef, Constant((uint)3)), Constant((ushort)7)), objRef);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(uint);
+            compiledA(ref exampleA);
+            Assert.AreEqual(3, exampleA);
+
+            var compiledB = lambda.CompileFast<ActionRef<uint>>(true);
+            var exampleB = default(uint);
+            compiledB(ref exampleB);
+            Assert.AreEqual(3, exampleB);
+
+            ActionRef<uint> direct = (ref uint x) => SetSmallConstant(ref x);
+            var exampleC = default(uint);
+            direct(ref exampleC);
+            Assert.AreEqual(3, exampleC);
+        }
+
+        [Test]
+        public void RefRefVoid()
+        {
+            void SetSmallConstant(ref int a1, ref float a2)
+            {             
+            }
             var objRef = Parameter(typeof(int).MakeByRefType());
-            var ret = Block(Label(Label(typeof(int)), Constant(default(int))));
-            var lambda = Lambda<IntRetrunByRefIntInt>(ret, objRef);
+            var objRef2 = Parameter(typeof(float).MakeByRefType());
+            var lambda = Lambda<ActionRefRef<int, float>>(Constant(default(object)), objRef, objRef2);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(int);
+            var exampleA2 = default(float);
+            compiledA(ref exampleA, ref exampleA2);
+            Assert.AreEqual(0, exampleA);
+
+            var compiledB = lambda.CompileFast<ActionRefRef<int, float>>(true);
+            var exampleB = default(int);
+            var exampleB2 = default(float);
+            compiledB(ref exampleB, ref exampleB2);
+            Assert.AreEqual(0, exampleB);
+
+            ActionRefRef<int, float> direct = SetSmallConstant;
+            var exampleC = default(int);
+            var exampleC2 = default(float);
+            direct(ref exampleC, ref exampleC2);
+            Assert.AreEqual(0, exampleC);
+        }
+
+        [Test]
+        public void RefRefReturnToVoid()
+        {
+            object SetSmallConstant(ref int a1, ref float a2)
+            {
+                return default(object);
+            }
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var objRef2 = Parameter(typeof(float).MakeByRefType());
+            var lambda = Lambda<ActionRefRef<int, float>>(Constant(default(object)), objRef, objRef2);
+
+            var compiledA = lambda.Compile();
+            var exampleA = default(int);
+            var exampleA2 = default(float);
+            compiledA(ref exampleA, ref exampleA2);
+            Assert.AreEqual(0, exampleA);
+
+            var compiledB = lambda.CompileFast<ActionRefRef<int, float>>(true);
+            var exampleB = default(int);
+            var exampleB2 = default(float);
+            compiledB(ref exampleB, ref exampleB2);
+            Assert.AreEqual(0, exampleB);
+
+            ActionRefRef<int, float> direct = (ref int x, ref float y) => SetSmallConstant(ref x, ref y);
+            var exampleC = default(int);
+            var exampleC2 = default(float);
+            direct(ref exampleC, ref exampleC2);
+            Assert.AreEqual(0, exampleC);
+        }
+
+        [Test]
+        public void RefDoNothingReturnCostant()
+        {
+            int DoNothing(ref int localByRef) => default(int);
+            var objRef = Parameter(typeof(int).MakeByRefType());
+            var lambda = Lambda<FuncRef<int, int>>(Constant(default(int)), objRef);
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             Assert.AreEqual(0, compiledA(ref exampleA));
             Assert.AreEqual(0, exampleA);
 
-            var compiledB = lambda.CompileFast<IntRetrunByRefIntInt>(true);
+            var compiledB = lambda.CompileFast<FuncRef<int, int>>(true);
             var exampleB = default(int);
             Assert.AreEqual(0, compiledB(ref exampleB));
             Assert.AreEqual(0, exampleB);
 
-            IntRetrunByRefIntInt direct = SetSmallConstant;
+            FuncRef<int, int> direct = DoNothing;
             var exampleC = default(int);
             Assert.AreEqual(0, direct(ref exampleC));
             Assert.AreEqual(0, exampleC);
@@ -116,19 +238,19 @@ namespace FastExpressionCompiler.IssueTests
                 localByRef = objVal;
             }
             var objRef = Parameter(typeof(int).MakeByRefType());
-            var lambda = Lambda<VoidReturnByRefIntIn>(Assign(objRef, Constant(42_123_666)), objRef);
+            var lambda = Lambda<ActionRef<int>>(Assign(objRef, Constant(42_123_666)), objRef);
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA);
             Assert.AreEqual(42_123_666, exampleA);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefIntIn>(true);
+            var compiledB = lambda.CompileFast<ActionRef<int>>(true);
             var exampleB = default(int);
             compiledB(ref exampleB);
             Assert.AreEqual(42_123_666, exampleB);
 
-            VoidReturnByRefIntIn direct = SetSmallConstant;
+            ActionRef<int> direct = SetSmallConstant;
             var exampleC = default(int);
             direct(ref exampleC);
             Assert.AreEqual(42_123_666, exampleC);
@@ -140,19 +262,6 @@ namespace FastExpressionCompiler.IssueTests
         // 1. newcomvers may look into il
         // 2. may call thes for test comparison
         // 3. as documentation of what is covered
-
-
-        private void Set1124144112Constant(ref int objRef)
-        {
-            const int objVal = 1124144112;
-            objRef = objVal;
-        }
-
-        private static void SetXXXXXConstant(ref int objRef)
-        {
-            const int objVal = 1124144112;
-            objRef = objVal;
-        }
 
         private void Set1124144112Constant(ref int objRef, ref int objRef2)
         {
@@ -178,23 +287,20 @@ namespace FastExpressionCompiler.IssueTests
             return x;
         }
 
-
-
-
         [Test]
         public void RefSetFromParameter()
         {
             var objRef = Parameter(typeof(int).MakeByRefType());
             var objVal = Parameter(typeof(int));
             var body = Assign(objRef, objVal);
-            var lambda = Lambda<VoidReturnByRefIntAndOtherIntIn>(body, objRef, objVal);
+            var lambda = Lambda<ActionRefIn<int, int>>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
             var exampleA = default(int);
             compiledA(ref exampleA, 7);
             Assert.AreEqual(7, exampleA);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefIntAndOtherIntIn>(true);
+            var compiledB = lambda.CompileFast<ActionRefIn<int, int>>(true);
             var exampleB = default(int);
             compiledB(ref exampleB, 7);
             Assert.AreEqual(7, exampleB);
@@ -209,14 +315,14 @@ namespace FastExpressionCompiler.IssueTests
             var objVal = Parameter(typeof(int));
             var prop = PropertyOrField(objRef, nameof(StructWithIntField.IntField));
             var body = Assign(prop, objVal);
-            var lambda = Lambda<VoidReturnByRefStructWithIntFieldAndIntIn>(body, objRef, objVal);
+            var lambda = Lambda<ActionRefIn<StructWithIntField, int>>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
             var exampleA = default(StructWithIntField);
             compiledA(ref exampleA, 7);
             Assert.AreEqual(7, exampleA.IntField);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefStructWithIntFieldAndIntIn>(true);
+            var compiledB = lambda.CompileFast<ActionRefIn<StructWithIntField, int>>(true);
             Assert.IsNull(compiledB);
         }
 
@@ -228,14 +334,14 @@ namespace FastExpressionCompiler.IssueTests
             var objVal = Parameter(typeof(int));
             var prop = PropertyOrField(objRef, nameof(StructWithIntField.IntField));
             var body = Assign(prop, objVal);
-            var lambda = Lambda<VoidReturnByRefTAndOtherIntIn<StructWithIntField>>(body, objRef, objVal);
+            var lambda = Lambda<ActionRefIn<StructWithIntField, int>>(body, objRef, objVal);
 
             var compiledA = lambda.Compile();
             var exampleA = default(StructWithIntField);
             compiledA(ref exampleA, 7);
             Assert.AreEqual(7, exampleA.IntField);
 
-            var compiledB = lambda.CompileFast<VoidReturnByRefTAndOtherIntIn<StructWithIntField>>(true);
+            var compiledB = lambda.CompileFast<ActionRefIn<StructWithIntField, int>>(true);
             Assert.IsNull(compiledB);
         }
     }

--- a/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
@@ -10,6 +10,7 @@ namespace FastExpressionCompiler.IssueTests
     // 1. multi ref set values
     // 2. `out` (out must be set - validate?)
     // 3. IntPtr and object ref tests
+    // 4. check support of `in` https://docs.microsoft.com/en-us/dotnet/csharp/language-reference/keywords/in-parameter-modifier
     [TestFixture]
     public class Issue55_CompileFast_crash_with_ref_parameter
     {


### PR DESCRIPTION
Hi, 

I have fixed 2 ref cases  and found 
1. need much more cases (adding and documenting samples for it inside test - will work as comparison example and docs and il starter for helpers)
2. for some reasons `.pop` in program gives bad program, not sure why that pop needed. How to be sure on performance? Better place for check?
3. need more support of types (i think unsigned list and tests)
4. ensure right ldarg param index (static, non static, closures)
5. There are 3 check for ByRef in code - check these are fine and unify
6. out, and return ref.

Could you please review and suggest something me to go in right direction? As of know I feel code to be `ref` unfriendly (how parameter are passed, fix for pop, casts)

Tests pass
![image](https://user-images.githubusercontent.com/757125/43888943-91d692d6-9bcb-11e8-92c1-e861d5c57045.png)