### PR TITLE
Tests for linq2db-generated expressions

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -256,5 +256,19 @@ namespace FastExpressionCompiler.IssueTests
 
             Assert.AreEqual(Enum2.Value2, compiled(Enum3.Value2));
         }
+
+        [Test]
+        public void AccessViolationException_on_nullable_char_convert_to_object()
+        {
+            var body = Expression.Convert(
+                Expression.Constant(' ', typeof(char?)),
+                typeof(object));
+
+            var expr = Expression.Lambda<Func<object>>(body);
+
+            var compiled = expr.CompileFast();
+
+            Assert.AreEqual(' ', compiled());
+        }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -279,6 +279,7 @@ namespace FastExpressionCompiler.IssueTests
         }
 
         [Test]
+        [Ignore("Test kills test runner process")]
         public void AccessViolationException_on_nullable_char_convert_to_object()
         {
             var body = Expression.Convert(

--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -226,5 +226,35 @@ namespace FastExpressionCompiler.IssueTests
             Assert.AreEqual(new Guid("ef129165-6ffe-4df9-bb6b-bb16e413c883"), res.GuidValue);
         }
 
+        enum Enum2
+        {
+            Value1 = 1,
+            Value2 = 2,
+        }
+
+        enum Enum3
+        {
+            Value1 = 1,
+            Value2 = 2,
+        }
+
+        [Test]
+        public void Enum_to_enum_conversion()
+        {
+            var from = typeof(Enum3);
+            var to = typeof(Enum2);
+
+            var p = Expression.Parameter(from, "p");
+
+            var body = Expression.Convert(
+                Expression.Convert(p, typeof(int)),
+                to);
+
+            var expr = Expression.Lambda<Func<Enum3, Enum2>>(body, p);
+
+            var compiled = expr.CompileFast();
+
+            Assert.AreEqual(Enum2.Value2, compiled(Enum3.Value2));
+        }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -1,0 +1,31 @@
+﻿using System;
+using System.Linq.Expressions;
+using NUnit.Framework;
+
+namespace FastExpressionCompiler.IssueTests
+{
+    [TestFixture]
+    public class Issue83_linq2db
+    {
+        [Test]
+        public void String_to_number_conversion_using_convert_with_method()
+        {
+            var from = typeof(string);
+            var to = typeof(int);
+
+            var p = Expression.Parameter(from, "p");
+
+            var body = Expression.Condition(
+                Expression.NotEqual(p, Expression.Constant(null, from)),
+                Expression.Convert(p, to, to.GetMethod(nameof(int.Parse), new[] { from })),
+                Expression.Constant(0));
+
+            var expr = Expression.Lambda<Func<string, int>>(body, p);
+
+            var compiled = expr.CompileFast();
+
+            Assert.AreEqual(10, compiled("10"));
+        }
+
+    }
+}


### PR DESCRIPTION
First test. To me it looks like Convert node with custom converter not handled properly.

Would say it is a big issue for linq2db as we use this approach a lot. Will check other failures and push more tests, but I would expect it to be main breaker for now.