### PR TITLE
Additional linq2db test

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -445,5 +445,85 @@ namespace FastExpressionCompiler.UnitTests
             Assert.Throws<NullReferenceException>(() => compiled2(null, null, null, null, null));
         }
 #endif
+
+        [Test]
+        public void Jit_compiler_internal_limitation()
+        {
+            var objParam = Parameter(typeof(object), "obj");
+            var valueParam = Parameter(typeof(object), "value");
+
+            var varClass2 = Variable(typeof(TestClass2));
+            var varClass3 = Variable(typeof(TestClass3));
+            var varClass4 = Variable(typeof(TestClass4));
+
+            var body = Block(
+                typeof(int),
+                new[] { varClass2, varClass3, varClass4 },
+                Assign(varClass2, Field(Convert(objParam, typeof(TestClass1)), nameof(TestClass1.Class2))),
+                IfThen(
+                    Equal(varClass2, Constant(null)),
+                    Block(
+                        Assign(varClass2, New(typeof(TestClass2))),
+                        Assign(Field(Convert(objParam, typeof(TestClass1)), nameof(TestClass1.Class2)), varClass2))),
+                Assign(varClass3, Field(varClass2, nameof(TestClass2.Class3))),
+                IfThen(
+                    Equal(varClass3, Constant(null)),
+                    Block(
+                        Assign(varClass3, New(typeof(TestClass3))),
+                        Assign(Field(varClass2, nameof(TestClass2.Class3)), varClass3))),
+                Assign(varClass4, Field(varClass3, nameof(TestClass3.Class4))),
+                IfThen(
+                    Equal(varClass4, Constant(null)),
+                    Block(
+                        Assign(varClass4, New(typeof(TestClass4))),
+                        Assign(Field(varClass3, nameof(TestClass3.Class4)), varClass4))),
+                Assign(
+                    Field(varClass4, nameof(TestClass4.Field1)),
+                    Convert(valueParam, typeof(int))));
+
+            var expr = Lambda<Action<object, object>>(body, objParam, valueParam);
+
+            var compiled = expr.CompileFast();
+
+            var obj = new TestClass1();
+
+            compiled(obj, 42);
+
+            Assert.That(obj.Class2.Class3.Class4.Field1, Is.EqualTo(42));
+        }
+
+        class TestClass1
+        {
+            public int Prop1
+            {
+                get { return 0; }
+            }
+
+            public int Prop2 { get; set; }
+
+            public TestClass2 Class2;
+
+            int _prop3;
+            public int Prop3
+            {
+                set { _prop3 = value; }
+            }
+        }
+
+        class TestClass2
+        {
+            public TestClass3 Class3;
+        }
+
+        class TestClass3
+        {
+            public TestClass4 Class4;
+        }
+
+        class TestClass4
+        {
+            public int Field1;
+        }
+
     }
 }


### PR DESCRIPTION
I've checked our non-database tests and only two similar tests fail with the same error.
This PR contains test for one of them as I think both tests fail for same reason.

@jogibear9988 I see you have some interest in this project. Could you work on tests/fixes for it? I really don't have much time for that and looking at number of failing sqlite tests it will take some time to fix them all. Currently we have 1100+ failing tests for SQLite only.
Most bizzare is assert failure for equality of two true values.