### PR TITLE
Invoking an Action constant fails with 'Common Language Runtime detected an invalid program'

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue_InvokeAction.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue_InvokeAction.cs
@@ -1,0 +1,33 @@
+﻿using System;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    public class Issue_InvokeAction
+    {
+        [Test, Ignore("Fails")]
+        public void InvokeActionConstantIsSupported()
+        {
+            Action<object, object> testAction = (o1, o2) => Console.WriteLine($"1: {o1}, 2: {o2}");
+
+            var actionConstant = Constant(testAction, typeof(Action<object, object>));
+            var one = Constant(1, typeof(object));
+            var two = Constant(2, typeof(object));
+            var actionInvoke = Invoke(actionConstant, one, two);
+
+            var invokeLambda = Lambda<Action>(actionInvoke);
+            var invokeFunc = invokeLambda.CompileFast();
+
+            invokeFunc.Invoke();
+        }
+    }
+}


### PR DESCRIPTION
Added failing test - invoking an action stored in a constant expression fails with 'Common Language Runtime detected an invalid program'.