### PR TITLE
Add another failing test from linq2db

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -1275,6 +1275,7 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        [Ignore("todo : fixme")]
         public void RenameMe()
         {
             var body = Convert(

--- a/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue83_linq2db.cs
@@ -1274,5 +1274,21 @@ namespace FastExpressionCompiler.UnitTests
             public TestClass3 Class3P { get; set; }
         }
 
+        [Test]
+        public void RenameMe()
+        {
+            var body = Convert(
+                Convert(
+                    Convert(
+                        Convert(Constant(2d), typeof(double?)),
+                        typeof(decimal),
+                        typeof(decimal).GetMethod("op_Explicit", new[] { typeof(double) })),
+                    typeof(decimal?)),
+                typeof(object));
+
+            var expr = Lambda<Func<object>>(body);
+            var compiled = expr.CompileFast(true);
+            Assert.AreEqual(2m, compiled());
+        }
     }
 }


### PR DESCRIPTION
PR contains test for only remaining issue we currently have with FEC in linq2db tests.

Linq2db test is [here](https://github.com/linq2db/linq2db/blob/master/Tests/Linq/Linq/MathFunctionTests.cs#L158) (it fails only for PostgreSQL provider).

@jogibear9988 FYI