### PR TITLE
- fixed deref of class field passed by ref

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -19,6 +19,20 @@
             "internalConsoleOptions": "openOnSessionStart"
         },
         {
+            "name": ".NET Core Launch (console tests)",
+            "type": "coreclr",
+            "request": "launch",
+            "preLaunchTask": "build",
+            // If you have changed target frameworks, make sure to update the program path.
+            "program": "${workspaceFolder}/test/FastExpressionCompiler.TestsRunner/bin/Debug/netcoreapp2.0/FastExpressionCompiler.TestsRunner.dll",
+            "args": [],
+            "cwd": "${workspaceFolder}/test/FastExpressionCompiler.TestsRunner",
+            // For more information about the 'console' field, see https://github.com/OmniSharp/omnisharp-vscode/blob/master/debugger-launchjson.md#console-terminal-window
+            "console": "internalConsole",
+            "stopAtEntry": false,
+            "internalConsoleOptions": "openOnSessionStart"
+        },        
+        {
             "name": ".NET Core Attach",
             "type": "coreclr",
             "request": "attach",

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1620,8 +1620,9 @@ namespace FastExpressionCompiler
 
                     if (paramExpr.IsByRef)
                     {
-                        if ((parent & ParentFlags.Coalesce) != 0)
-                            il.Emit(OpCodes.Ldind_Ref); // Coalesce on for ref types
+                        if (((parent & ParentFlags.MemberAccess) != 0 && paramType.IsClass) ||
+                            ((parent & ParentFlags.Coalesce) != 0))
+                            il.Emit(OpCodes.Ldind_Ref); 
                         else if ((parent & ParentFlags.Arithmetic) != 0)
                             EmitDereference(il, paramType);
                     }

--- a/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue55_CompileFast_crash_with_ref_parameter.cs
@@ -16,8 +16,8 @@ using static System.Linq.Expressions.Expression;
 namespace FastExpressionCompiler.UnitTests
 #endif
 {
-// considers in/out/ref in C# represented by ByRef in expressions (i.e. single representation for 3 C# keywords)
-[TestFixture]
+    // considers in/out/ref in C# represented by ByRef in expressions (i.e. single representation for 3 C# keywords)
+    [TestFixture]
     public class Issue55_CompileFast_crash_with_ref_parameter
     {
         delegate TResult FuncRef<T, out TResult>(ref T a1);
@@ -625,9 +625,9 @@ namespace FastExpressionCompiler.UnitTests
             var body = Assign(prop, objVal);
             var lambda = Lambda<ActionRefIn<StructWithIntField, int>>(body, objRef, objVal);
 
-            var compiledB = lambda.CompileFast<ActionRefIn<StructWithIntField, int>>(true);
+            var fastCompiled = lambda.CompileFast<ActionRefIn<StructWithIntField, int>>(true);
             var exampleB = default(StructWithIntField);
-            compiledB(ref exampleB, 7);
+            fastCompiled(ref exampleB, 7);
             Assert.AreEqual(7, exampleB.IntField);
         }
 
@@ -703,7 +703,7 @@ namespace FastExpressionCompiler.UnitTests
             void DynamicDeserializer(ref object value) =>
                 value = value ?? new object();
 
-            void DynamicDeserializerGeneric<T>(ref T value) where T:class, new () =>
+            void DynamicDeserializerGeneric<T>(ref T value) where T : class, new() =>
                 value = value ?? new T();
 
             var specificType = typeof(object);
@@ -802,7 +802,5 @@ namespace FastExpressionCompiler.UnitTests
             LocalAssert(funcFast);
             LocalAssert(TryParseReturn);
         }
-
-
-        }
     }
+}

--- a/test/FastExpressionCompiler.IssueTests/Issue67_Equality_comparison_with_nullables_throws_at_delegate_invoke.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue67_Equality_comparison_with_nullables_throws_at_delegate_invoke.cs
@@ -4,7 +4,7 @@ using System.Linq.Expressions;
 using NUnit.Framework;
 #pragma warning disable 219
 
-namespace FastExpressionCompiler.IssueTests
+namespace FastExpressionCompiler.UnitTests
 {
     [TestFixture]
     public class Issue67_Equality_comparison_with_nullables_throws_at_delegate_invoke

--- a/test/FastExpressionCompiler.IssueTests/Issue72_Try_CompileFast_for_MS_Extensions_ObjectMethodExecutor.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue72_Try_CompileFast_for_MS_Extensions_ObjectMethodExecutor.cs
@@ -6,7 +6,7 @@ using System.Threading.Tasks;
 using Microsoft.Extensions.Internal;
 using NUnit.Framework;
 
-namespace FastExpressionCompiler.IssueTests
+namespace FastExpressionCompiler.UnitTests
 {
     [TestFixture]
     public class Issue72_Try_CompileFast_for_MS_Extensions_ObjectMethodExecutor

--- a/test/FastExpressionCompiler.IssueTests/Issues170_Serializer_Person_Ref.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issues170_Serializer_Person_Ref.cs
@@ -72,7 +72,7 @@ namespace FastExpressionCompiler.UnitTests
 #endif
 
             var funcFast = lambda.CompileFast();
-            LocalAssert(funcFast);            
+            LocalAssert(funcFast);
         }
 
         delegate void DeserializeDelegateSimple<T>(ref T value);
@@ -89,7 +89,7 @@ namespace FastExpressionCompiler.UnitTests
             var refValueArg = Parameter(typeof(SimplePerson).MakeByRefType(), "value");
             void AssingRefs(ref SimplePerson value) => value.Health = 5;
             var lambda = Lambda<DeserializeDelegateSimple<SimplePerson>>(
-                Assign(PropertyOrField(refValueArg, nameof(SimplePerson.Health)), Constant(5)), 
+                Assign(PropertyOrField(refValueArg, nameof(SimplePerson.Health)), Constant(5)),
                 refValueArg);
 
 
@@ -101,7 +101,7 @@ namespace FastExpressionCompiler.UnitTests
             }
 
             LocalAssert(AssingRefs);
- 
+
 #if !LIGHT_EXPRESSION
             {
                 var func = lambda.Compile();
@@ -111,7 +111,7 @@ namespace FastExpressionCompiler.UnitTests
 
 
             var funcFast = lambda.CompileFast();
-            LocalAssert(funcFast);            
+            LocalAssert(funcFast);
         }
 
 
@@ -121,15 +121,18 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+#if LIGHT_EXPRESSION
+        [Ignore("Fix ArgumentException for LIGHT_EXPRESSION")]
+#endif
         public void InvokeActionConstantIsSupportedSimpleStruct()
         {
             var refValueArg = Parameter(typeof(SimplePersonStruct).MakeByRefType(), "value");
 
             void AssingRefs(ref SimplePersonStruct value) => value.Health = 5;
-            
+
 
             var lambda = Lambda<DeserializeDelegateSimple<SimplePersonStruct>>(
-                Assign(PropertyOrField(refValueArg, nameof(SimplePersonStruct.Health)), Constant(5)), 
+                Assign(PropertyOrField(refValueArg, nameof(SimplePersonStruct.Health)), Constant(5)),
                 refValueArg);
 
             void LocalAssert(DeserializeDelegateSimple<SimplePersonStruct> invoke)
@@ -141,15 +144,14 @@ namespace FastExpressionCompiler.UnitTests
 
             LocalAssert(AssingRefs);
 
-#if !LIGHT_EXPRESSION
-            {
-                var func = lambda.Compile();                
-                LocalAssert(func);
-            }
+            var func = lambda
+#if LIGHT_EXPRESSION
+                .ToLambdaExpression()
 #endif
+                .Compile();
 
             var funcFast = lambda.CompileFast();
-            LocalAssert(funcFast);            
+            LocalAssert(funcFast);
         }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issues170_Serializer_Person_Ref.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issues170_Serializer_Person_Ref.cs
@@ -1,0 +1,155 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Numerics;
+using System.Reflection;
+using NUnit.Framework;
+
+#pragma warning disable 649
+#pragma warning disable 219
+
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    [TestFixture]
+    public class Issues170_Serializer_Person_Ref
+    {
+        delegate void DeserializeDelegate<T>(byte[] buffer, ref int offset, ref T value);
+
+
+        class Person
+        {
+            public string Name;
+            public int Health;
+            public Person BestFriend;
+        }
+
+        [Test]
+        public void InvokeActionConstantIsSupported()
+        {
+            var bufferArg = Parameter(typeof(byte[]), "buffer");
+            var refOffsetArg = Parameter(typeof(int).MakeByRefType(), "offset");
+            var refValueArg = Parameter(typeof(Person).MakeByRefType(), "value");
+
+            var assignBlock = Block(
+                Assign(PropertyOrField(refValueArg, nameof(Person.Health)), Constant(5)),
+                Assign(PropertyOrField(refValueArg, nameof(Person.Name)), Constant("test result name"))
+               );
+
+            void AssingRefs(byte[] buffer, ref int offset, ref Person value)
+            {
+                value.Health = 5;
+                value.Name = "test result name";
+            }
+
+            var lambda = Lambda<DeserializeDelegate<Person>>(assignBlock, bufferArg, refOffsetArg, refValueArg);
+
+
+            void LocalAssert(DeserializeDelegate<Person> invoke)
+            {
+                var person = new Person { Name = "a", Health = 1 };
+                byte[] buffer = new byte[100];
+                int offset = 0;
+
+                invoke(null, ref offset, ref person);
+                Assert.AreEqual(5, person.Health);
+                Assert.AreEqual("test result name", person.Name);
+            }
+
+            LocalAssert(AssingRefs);
+
+#if !LIGHT_EXPRESSION
+            {
+                var func = lambda.Compile();
+                LocalAssert(func);
+            }
+#endif
+
+            var funcFast = lambda.CompileFast();
+            LocalAssert(funcFast);            
+        }
+
+        delegate void DeserializeDelegateSimple<T>(ref T value);
+
+
+        class SimplePerson
+        {
+            public int Health;
+        }
+
+        [Test]
+        public void InvokeActionConstantIsSupportedSimple()
+        {
+            var refValueArg = Parameter(typeof(SimplePerson).MakeByRefType(), "value");
+            void AssingRefs(ref SimplePerson value) => value.Health = 5;
+            var lambda = Lambda<DeserializeDelegateSimple<SimplePerson>>(
+                Assign(PropertyOrField(refValueArg, nameof(SimplePerson.Health)), Constant(5)), 
+                refValueArg);
+
+
+            void LocalAssert(DeserializeDelegateSimple<SimplePerson> invoke)
+            {
+                var person = new SimplePerson { Health = 1 };
+                invoke(ref person);
+                Assert.AreEqual(5, person.Health);
+            }
+
+            LocalAssert(AssingRefs);
+ 
+#if !LIGHT_EXPRESSION
+            {
+                var func = lambda.Compile();
+                LocalAssert(func);
+            }
+#endif
+
+
+            var funcFast = lambda.CompileFast();
+            LocalAssert(funcFast);            
+        }
+
+
+        struct SimplePersonStruct
+        {
+            public int Health;
+        }
+
+        [Test]
+        public void InvokeActionConstantIsSupportedSimpleStruct()
+        {
+            var refValueArg = Parameter(typeof(SimplePersonStruct).MakeByRefType(), "value");
+
+            void AssingRefs(ref SimplePersonStruct value) => value.Health = 5;
+            
+
+            var lambda = Lambda<DeserializeDelegateSimple<SimplePersonStruct>>(
+                Assign(PropertyOrField(refValueArg, nameof(SimplePersonStruct.Health)), Constant(5)), 
+                refValueArg);
+
+            void LocalAssert(DeserializeDelegateSimple<SimplePersonStruct> invoke)
+            {
+                var person = new SimplePersonStruct { Health = 1 };
+                invoke(ref person);
+                Assert.AreEqual(5, person.Health);
+            }
+
+            LocalAssert(AssingRefs);
+
+#if !LIGHT_EXPRESSION
+            {
+                var func = lambda.Compile();                
+                LocalAssert(func);
+            }
+#endif
+
+            var funcFast = lambda.CompileFast();
+            LocalAssert(funcFast);            
+        }
+    }
+}

--- a/test/FastExpressionCompiler.TestsRunner/FastExpressionCompiler.TestsRunner.csproj
+++ b/test/FastExpressionCompiler.TestsRunner/FastExpressionCompiler.TestsRunner.csproj
@@ -1,0 +1,12 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <ItemGroup>
+    <ProjectReference Include="..\FastExpressionCompiler.IssueTests\FastExpressionCompiler.IssueTests.csproj" />
+  </ItemGroup>
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>netcoreapp2.0</TargetFramework>
+  </PropertyGroup>
+
+</Project>

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -1,11 +1,13 @@
 ﻿namespace FastExpressionCompiler.UnitTests
 {
-    
+
     public class Program
     {
         public static void Main()
         {
-            // TODO: Use NUnit classes to run tests. But better to migrate to xunit (xunit is de facto standard fot testing ALL MS stuff)
+            // TODO: Use NUnit classes to run tests via NUnit.Engine.Api (after update to newer NUnit 3.9 for forward looking Engine API)
+            // TODO: Or migrate to xunit (xunit is de facto standard fot testing all  .NET FX stuff)
+            //
             // replace with you test to Debug
             // var test = new Issues170_Serializer_Person_Ref();
             // test.InvokeActionConstantIsSupportedSimpleStruct();

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -1,0 +1,14 @@
+﻿namespace FastExpressionCompiler.UnitTests
+{
+    
+    public class Program
+    {
+        public static void Main()
+        {
+            // TODO: Use NUnit classes to run tests. But better to migrate to xunit (xunit is de facto standard fot testing ALL MS stuff)
+            // replace with you test to Debug
+            // var test = new Issues170_Serializer_Person_Ref();
+            // test.InvokeActionConstantIsSupportedSimpleStruct();
+        }
+    }
+}


### PR DESCRIPTION
- allowed people without R# or NCrunh or Rider (e.g. VS Community with always buggy NUnit adapter or VS Code with buggy adapter) to run DEBUG tests
- change 2 tests into same namespace as others
#170 