### PR TITLE
Added failing test for #181

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using NUnit.Framework;
+#pragma warning disable 659
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    public class Issue181_TryEmitIncDecAssign_InvalidCastException
+    {
+        // originally seen in a Rezolver example, which I've tried to replicate as close as possible
+
+        public int Counter { get; set; } = 1;
+
+
+        [Test]
+        public void TryEmitIncDecAssign_DoesntThrow_InvalidCastException()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+                PreIncrementAssign(
+                    Property(p, nameof(Counter))
+                ),
+                p);
+ 
+            var del = lambda.CompileFast();
+            Assert.AreEqual(Counter + 1, del.Invoke(this));
+        }
+    }
+}


### PR DESCRIPTION
Failing test for #181 - fails for both Linq expressions and Light expressions.

The problem is that `TryEmitIncDecAssign` only supports targets which have been emitted as local variables in a closure (so, presumably it will also not work for fields).

When the operand is a Property, it would need to get the value via the `get` accessor, increment the result, and then write it back to the property via its set accessor; it should then push the value on the stack so it can be 'returned'.  It's been a while since I last did a lot of IL, but I think this can be done without a local.

In fact, as I was writing that, I thought that perhaps you've already done this elsewhere - and I see that `TryEmitAssign` has a strategy for the different types of left-hand targets - and, indeed, it supports Properties, as well as indexers - so it looks like `TryEmitIncDecAssign` needs to be changed to have a similar branching strategy for each potential target.

I did start having a go at fixing, but I can't squeeze it into the time I have right now, sorry!  If you don't get round to it once I'm done with the stuff I'm on, then perhaps I'll try to get back to it.