### PR TITLE
Improve compatability with the Framework

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -336,8 +336,8 @@ namespace FastExpressionCompiler.LightExpression
             new Expression<TDelegate>(body, parameters);
 
         /// <summary>Creates a BinaryExpression that represents applying an array index operator to an array of rank one.</summary>
-        /// <param name="left">An Expression to set the Left property equal to.</param>
-        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <param name="array">A Expression to set the Left property equal to.</param>
+        /// <param name="index">A Expression to set the Right property equal to.</param>
         /// <returns>A BinaryExpression that has the NodeType property equal to ArrayIndex and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression ArrayIndex(Expression array, Expression index) =>
             new ArrayIndexExpression(array, index, array.Type.GetElementType());

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -222,6 +222,10 @@ namespace FastExpressionCompiler.LightExpression
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body, string name, params ParameterExpression[] parameters) =>
             new Expression<TDelegate>(body, parameters);
 
+        /// <summary>Creates a BinaryExpression that represents applying an array index operator to an array of rank one.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to ArrayIndex and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression ArrayIndex(Expression array, Expression index) =>
             new ArrayIndexExpression(array, index, array.Type.GetElementType());
 
@@ -243,21 +247,108 @@ namespace FastExpressionCompiler.LightExpression
                 bounds.Length == 1 ? type.MakeArrayType() : type.MakeArrayType(bounds.Length),
                 bounds);
 
+        /// <summary>Creates a BinaryExpression that represents an assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Assign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression Assign(Expression left, Expression right) =>
             new AssignBinaryExpression(left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents raising an expression to a power and assigning the result back to the expression.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to PowerAssign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression PowerAssign(Expression left, Expression right) =>
             new AssignBinaryExpression(ExpressionType.PowerAssign, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents an addition assignment operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to AddAssign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression AddAssign(Expression left, Expression right) =>
             new AssignBinaryExpression(ExpressionType.AddAssign, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents an addition assignment operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to AddAssignChecked and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression AddAssignChecked(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.AddAssignChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise AND assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to AndAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression AndAssign(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.AndAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise XOR assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to ExclusiveOrAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression ExclusiveOrAssign(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.ExclusiveOrAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise left-shift assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to LeftShiftAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression LeftShiftAssign(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.LeftShiftAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a remainder assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to ModuloAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression ModuloAssign(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.ModuloAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise OR assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to OrAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression OrAssign(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.OrAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise right-shift assignment operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to RightShiftAssign and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression RightShiftAssign(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.RightShiftAssign, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a subtraction assignment operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to SubtractAssign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression SubtractAssign(Expression left, Expression right) =>
             new AssignBinaryExpression(ExpressionType.SubtractAssign, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents a subtraction assignment operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to SubtractAssignChecked and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression SubtractAssignChecked(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.SubtractAssignChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a multiplication assignment operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to MultiplyAssign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression MultiplyAssign(Expression left, Expression right) =>
             new AssignBinaryExpression(ExpressionType.MultiplyAssign, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents a multiplication assignment operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to MultiplyAssignChecked and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression MultiplyAssignChecked(Expression left, Expression right) =>
+            new AssignBinaryExpression(ExpressionType.MultiplyAssignChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a division assignment operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to DivideAssign and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression DivideAssign(Expression left, Expression right) =>
             new AssignBinaryExpression(ExpressionType.DivideAssign, left, right, left.Type);
 
@@ -285,47 +376,159 @@ namespace FastExpressionCompiler.LightExpression
         public static ConditionalExpression IfThenElse(Expression test, Expression ifTrue, Expression ifFalse) =>
             Condition(test, ifTrue, ifFalse, typeof(void));
 
-        public static Expression Add(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents an arithmetic addition operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Add and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Add(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.Add, left, right, left.Type);
 
-        public static Expression Substract(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents an arithmetic addition operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to AddChecked and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression AddChecked(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.AddChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise XOR operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to ExclusiveOr and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression ExclusiveOr(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.ExclusiveOr, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise left-shift operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to LeftShift and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression LeftShift(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.LeftShift, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents an arithmetic remainder operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Modulo and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Modulo(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.Modulo, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise OR operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Or and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Or(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.Or, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents a bitwise right-shift operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to RightShift and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression RightShift(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.RightShift, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents an arithmetic subtraction operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Subtract and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Subtract(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.Subtract, left, right, left.Type);
 
-        public static Expression Multiply(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents an arithmetic subtraction operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to SubtractChecked and the Left, Right, and Method properties set to the specified values.</returns>
+        public static BinaryExpression SubtractChecked(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.SubtractChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents an arithmetic multiplication operation that does not have overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Multiply and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Multiply(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.Multiply, left, right, left.Type);
 
-        public static Expression Divide(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents an arithmetic multiplication operation that has overflow checking.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to MultiplyChecked and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression MultiplyChecked(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.MultiplyChecked, left, right, left.Type);
+
+        /// <summary>Creates a BinaryExpression that represents an arithmetic division operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Divide and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Divide(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.Divide, left, right, left.Type);
 
-        public static Expression Power(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents raising a number to a power.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Power and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Power(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.Power, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents a bitwise AND operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to And and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression And(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.And, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents a conditional AND operation that evaluates the second operand only if the first operand evaluates to true.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to AndAlso and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression AndAlso(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.AndAlso, left, right, left.Type);
 
+        /// <summary>Creates a BinaryExpression that represents a conditional OR operation that evaluates the second operand only if the first operand evaluates to false.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to OrElse and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression OrElse(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.OrElse, left, right, left.Type);
 
-        public static Expression Equal(Expression left, Expression right) =>
-            new SimpleBinaryExpression(ExpressionType.Equal, left, right, left.Type);
+        /// <summary>Creates a BinaryExpression that represents an equality comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Equal and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression Equal(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.Equal, left, right, typeof(bool));
 
-        public static Expression GreaterThan(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents a "greater than" numeric comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to GreaterThan and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression GreaterThan(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.GreaterThan, left, right, left.Type);
 
-        public static Expression GreaterThanOrEqual(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents a "greater than or equal" numeric comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to GreaterThanOrEqual and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression GreaterThanOrEqual(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.GreaterThanOrEqual, left, right, left.Type);
 
-        public static Expression LessThan(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents a "less than" numeric comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to LessThan and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression LessThan(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.LessThan, left, right, left.Type);
 
-        public static Expression LessThanOrEqual(Expression left, Expression right) =>
+        /// <summary>Creates a BinaryExpression that represents a " less than or equal" numeric comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to LessThanOrEqual and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression LessThanOrEqual(Expression left, Expression right) =>
             new SimpleBinaryExpression(ExpressionType.LessThanOrEqual, left, right, left.Type);
 
-        public static Expression NotEqual(Expression left, Expression right) =>
-            new SimpleBinaryExpression(ExpressionType.NotEqual, left, right, left.Type);
+        /// <summary>Creates a BinaryExpression that represents an inequality comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to NotEqual and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression NotEqual(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.NotEqual, left, right, typeof(bool));
 
         public static BlockExpression Block(params Expression[] expressions) =>
             Block(Tools.Empty<ParameterExpression>(), expressions);
@@ -363,6 +566,41 @@ namespace FastExpressionCompiler.LightExpression
         public static LabelTarget Label(string name) =>
             SysExpr.Label(typeof(void), name);
 
+        /// <summary>Creates a BinaryExpression, given the left and right operands, by calling an appropriate factory method.</summary>
+        /// <param name="binaryType">The ExpressionType that specifies the type of binary operation.</param>
+        /// <param name="left">An Expression that represents the left operand.</param>
+        /// <param name="right">An Expression that represents the right operand.</param>
+        /// <returns>The BinaryExpression that results from calling the appropriate factory method.</returns>
+        public static BinaryExpression MakeBinary(ExpressionType binaryType, Expression left, Expression right)
+        {
+            switch (binaryType)
+            {
+                case ExpressionType.AddAssign:
+                case ExpressionType.AddAssignChecked:
+                case ExpressionType.AndAssign:
+                case ExpressionType.Assign:
+                case ExpressionType.DivideAssign:
+                case ExpressionType.ExclusiveOrAssign:
+                case ExpressionType.LeftShiftAssign:
+                case ExpressionType.ModuloAssign:
+                case ExpressionType.MultiplyAssign:
+                case ExpressionType.MultiplyAssignChecked:
+                case ExpressionType.OrAssign:
+                case ExpressionType.PowerAssign:
+                case ExpressionType.RightShiftAssign:
+                case ExpressionType.SubtractAssign:
+                case ExpressionType.SubtractAssignChecked:
+                    return new AssignBinaryExpression(binaryType, left, right, left.Type);
+                case ExpressionType.ArrayIndex:
+                    return ArrayIndex(left, right);
+                case ExpressionType.Coalesce:
+                    return Coalesce(left, right);
+                default:
+                    return new SimpleBinaryExpression(binaryType, left, right, left.Type);
+            }
+        }
+
+
         public static GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type = null) =>
             new GotoExpression(kind, target, value, type ?? typeof(void));
 
@@ -371,6 +609,20 @@ namespace FastExpressionCompiler.LightExpression
 
         public static GotoExpression Continue(LabelTarget target, Type type = null) =>
             MakeGoto(GotoExpressionKind.Continue, target, null, type);
+
+        /// <summary>Creates a BinaryExpression that represents a reference equality comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Equal and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression ReferenceEqual(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.Equal, left, right, typeof(bool));
+
+        /// <summary>Creates a BinaryExpression that represents a reference inequality comparison.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to NotEqual and the Left and Right properties set to the specified values.</returns>
+        public static BinaryExpression ReferenceNotEqual(Expression left, Expression right) =>
+            new SimpleBinaryExpression(ExpressionType.NotEqual, left, right, typeof(bool));
 
         public static GotoExpression Return(LabelTarget target, Expression value = null, Type type = null) =>
             MakeGoto(GotoExpressionKind.Return, target, value);
@@ -399,8 +651,17 @@ namespace FastExpressionCompiler.LightExpression
         public static SwitchCase SwitchCase(Expression body, params Expression[] testValues) =>
             new SwitchCase(body, testValues);
 
+        /// <summary>Creates a BinaryExpression that represents a coalescing operation.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Coalesce and the Left and Right properties set to the specified values.</returns>
         public static BinaryExpression Coalesce(Expression left, Expression right) => Coalesce(left, right, null);
 
+        /// <summary>Creates a BinaryExpression that represents a coalescing operation, given a conversion function.</summary>
+        /// <param name="left">An Expression to set the Left property equal to.</param>
+        /// <param name="right">An Expression to set the Right property equal to.</param>
+        /// <param name="conversion">A LambdaExpression to set the Conversion property equal to.</param>
+        /// <returns>A BinaryExpression that has the NodeType property equal to Coalesce and the Left, Right and Conversion properties set to the specified values.</returns>
         public static BinaryExpression Coalesce(Expression left, Expression right, LambdaExpression conversion) =>
             conversion == null ?
                 new SimpleBinaryExpression(ExpressionType.Coalesce, left, right, GetCoalesceType(left.Type, right.Type)) :

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -936,9 +936,43 @@ namespace FastExpressionCompiler.LightExpression
 
         public override SysExpr ToExpression()
         {
-            if (NodeType == ExpressionType.Convert)
-                return SysExpr.Convert(Operand.ToExpression(), Type);
-            throw new NotSupportedException("Cannot convert Expression to Expression of type " + NodeType);
+            switch (NodeType)
+            {
+                case ExpressionType.ArrayLength:
+                    return SysExpr.ArrayLength(Operand.ToExpression());
+                case ExpressionType.Convert:
+                    return SysExpr.Convert(Operand.ToExpression(), Type);
+                case ExpressionType.Decrement:
+                    return SysExpr.Decrement(Operand.ToExpression());
+                case ExpressionType.Increment:
+                    return SysExpr.Increment(Operand.ToExpression());
+                case ExpressionType.IsFalse:
+                    return SysExpr.IsFalse(Operand.ToExpression());
+                case ExpressionType.IsTrue:
+                    return SysExpr.IsTrue(Operand.ToExpression());
+                case ExpressionType.Negate:
+                    return SysExpr.Negate(Operand.ToExpression());
+                case ExpressionType.NegateChecked:
+                    return SysExpr.NegateChecked(Operand.ToExpression());
+                case ExpressionType.OnesComplement:
+                    return SysExpr.OnesComplement(Operand.ToExpression());
+                case ExpressionType.PostDecrementAssign:
+                    return SysExpr.PostDecrementAssign(Operand.ToExpression());
+                case ExpressionType.PostIncrementAssign:
+                    return SysExpr.PostIncrementAssign(Operand.ToExpression());
+                case ExpressionType.PreDecrementAssign:
+                    return SysExpr.PreDecrementAssign(Operand.ToExpression());
+                case ExpressionType.PreIncrementAssign:
+                    return SysExpr.PreIncrementAssign(Operand.ToExpression());
+                case ExpressionType.Quote:
+                    return SysExpr.Quote(Operand.ToExpression());
+                case ExpressionType.UnaryPlus:
+                    return SysExpr.UnaryPlus(Operand.ToExpression());
+                case ExpressionType.Unbox:
+                    return SysExpr.Unbox(Operand.ToExpression(), Type);
+                default:
+                    throw new NotSupportedException("Cannot convert Expression to Expression of type " + NodeType);
+            }
         }
 
         public UnaryExpression(ExpressionType nodeType, Expression operand, Type type)

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -177,11 +177,18 @@ namespace FastExpressionCompiler.LightExpression
         public static LambdaExpression Lambda(Type delegateType, Expression body, params ParameterExpression[] parameters) =>
             new LambdaExpression(delegateType, body, parameters);
 
-        public static UnaryExpression Not(Expression operand) =>
-            new UnaryExpression(ExpressionType.Not, operand, operand.Type);
+        /// <summary>Creates a UnaryExpression that represents a bitwise complement operation.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Not and the Operand property set to the specified value.</returns>
+        public static UnaryExpression Not(Expression expression) =>
+            new UnaryExpression(ExpressionType.Not, expression, expression.Type);
 
-        public static UnaryExpression TypeAs(Expression operand, Type type) =>
-            new UnaryExpression(ExpressionType.TypeAs, operand, type);
+        /// <summary>Creates a UnaryExpression that represents an explicit reference or boxing conversion where null is supplied if the conversion fails.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to TypeAs and the Operand and Type properties set to the specified values.</returns>
+        public static UnaryExpression TypeAs(Expression expression, Type type) =>
+            new UnaryExpression(ExpressionType.TypeAs, expression, type);
 
         public static TypeBinaryExpression TypeEqual(Expression operand, Type type) =>
             new TypeBinaryExpression(ExpressionType.TypeEqual, operand, type);
@@ -189,29 +196,135 @@ namespace FastExpressionCompiler.LightExpression
         public static TypeBinaryExpression TypeIs(Expression operand, Type type) =>
             new TypeBinaryExpression(ExpressionType.TypeIs, operand, type);
 
-        public static UnaryExpression Convert(Expression operand, Type targetType) =>
-            new UnaryExpression(ExpressionType.Convert, operand, targetType);
+        /// <summary>Creates a UnaryExpression that represents an expression for obtaining the length of a one-dimensional array.</summary>
+        /// <param name="array">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to ArrayLength and the Operand property equal to array.</returns>
+        public static UnaryExpression ArrayLength(Expression array) =>
+            new UnaryExpression(ExpressionType.ArrayLength, array, typeof(int));
 
-        public static UnaryExpression Convert(Expression operand, Type targetType, MethodInfo method) =>
-            new UnaryExpression(ExpressionType.Convert, operand, targetType, method);
+        /// <summary>Creates a UnaryExpression that represents a type conversion operation.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Convert and the Operand and Type properties set to the specified values.</returns>
+        public static UnaryExpression Convert(Expression expression, Type type) =>
+            Convert(expression, type, null);
 
-        public static UnaryExpression ConvertChecked(Expression operand, Type targetType) =>
-            new UnaryExpression(ExpressionType.ConvertChecked, operand, targetType);
+        /// <summary>Creates a UnaryExpression that represents a conversion operation for which the implementing method is specified.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <param name="method">A MethodInfo to set the Method property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Convert and the Operand, Type, and Method properties set to the specified values.</returns>
+        public static UnaryExpression Convert(Expression expression, Type type, MethodInfo method) =>
+            new UnaryExpression(ExpressionType.Convert, expression, type, method);
 
-        public static UnaryExpression ConvertChecked(Expression operand, Type targetType, MethodInfo method) =>
-            new UnaryExpression(ExpressionType.ConvertChecked, operand, targetType, method);
+        /// <summary>Creates a UnaryExpression that represents a conversion operation that throws an exception if the target type is overflowed.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to ConvertChecked and the Operand and Type properties set to the specified values.</returns>
+        public static UnaryExpression ConvertChecked(Expression expression, Type type) =>
+            ConvertChecked(expression, type, null);
 
-        public static UnaryExpression PreIncrementAssign(Expression operand) =>
-            new UnaryExpression(ExpressionType.PreIncrementAssign, operand, operand.Type);
+        /// <summary>Creates a UnaryExpression that represents a conversion operation that throws an exception if the target type is overflowed and for which the implementing method is specified.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <param name="method">A MethodInfo to set the Method property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to ConvertChecked and the Operand, Type, and Method properties set to the specified values.</returns>
+        public static UnaryExpression ConvertChecked(Expression expression, Type type, MethodInfo method) =>
+            new UnaryExpression(ExpressionType.ConvertChecked, expression, type, method);
 
-        public static UnaryExpression PostIncrementAssign(Expression operand) =>
-            new UnaryExpression(ExpressionType.PostIncrementAssign, operand, operand.Type);
+        /// <summary>Creates a UnaryExpression that represents the decrementing of the expression by 1.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the decremented expression.</returns>
+        public static UnaryExpression Decrement(Expression expression) =>
+            new UnaryExpression(ExpressionType.Decrement, expression, expression.Type);
 
-        public static UnaryExpression PreDecrementAssign(Expression operand) =>
-            new UnaryExpression(ExpressionType.PreDecrementAssign, operand, operand.Type);
+        /// <summary>Creates a UnaryExpression that represents the incrementing of the expression value by 1.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the incremented expression.</returns>
+        public static UnaryExpression Increment(Expression expression) =>
+            new UnaryExpression(ExpressionType.Increment, expression, expression.Type);
 
-        public static UnaryExpression PostDecrementAssign(Expression operand) =>
-            new UnaryExpression(ExpressionType.PostDecrementAssign, operand, operand.Type);
+        /// <summary>Returns whether the expression evaluates to false.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>An instance of UnaryExpression.</returns>
+        public static UnaryExpression IsFalse(Expression expression) =>
+            new UnaryExpression(ExpressionType.IsFalse, expression, typeof(bool));
+
+        /// <summary>Returns whether the expression evaluates to true.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>An instance of UnaryExpression.</returns>
+        public static UnaryExpression IsTrue(Expression expression) =>
+            new UnaryExpression(ExpressionType.IsTrue, expression, typeof(bool));
+
+        /// <summary>Creates a UnaryExpression, given an operand, by calling the appropriate factory method.</summary>
+        /// <param name="unaryType">The ExpressionType that specifies the type of unary operation.</param>
+        /// <param name="operand">An Expression that represents the operand.</param>
+        /// <param name="type">The Type that specifies the type to be converted to (pass null if not applicable).</param>
+        /// <returns>The UnaryExpression that results from calling the appropriate factory method.</returns>
+        public static UnaryExpression MakeUnary(ExpressionType unaryType, Expression operand, Type type) =>
+            new UnaryExpression(unaryType, operand, type);
+
+        /// <summary>Creates a UnaryExpression that represents an arithmetic negation operation.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Negate and the Operand property set to the specified value.</returns>
+        public static UnaryExpression Negate(Expression expression) =>
+            new UnaryExpression(ExpressionType.Negate, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents an arithmetic negation operation that has overflow checking.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to NegateChecked and the Operand property set to the specified value.</returns>
+        public static UnaryExpression NegateChecked(Expression expression) =>
+            new UnaryExpression(ExpressionType.NegateChecked, expression, expression.Type);
+
+        /// <summary>Returns the expression representing the ones complement.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>An instance of UnaryExpression.</returns>
+        public static UnaryExpression OnesComplement(Expression expression) =>
+            new UnaryExpression(ExpressionType.OnesComplement, expression, expression.Type);
+
+
+        /// <summary>Creates a UnaryExpression that increments the expression by 1 and assigns the result back to the expression.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the resultant expression.</returns>
+        public static UnaryExpression PreIncrementAssign(Expression expression) =>
+            new UnaryExpression(ExpressionType.PreIncrementAssign, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents the assignment of the expression followed by a subsequent increment by 1 of the original expression.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the resultant expression.</returns>
+        public static UnaryExpression PostIncrementAssign(Expression expression) =>
+            new UnaryExpression(ExpressionType.PostIncrementAssign, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that decrements the expression by 1 and assigns the result back to the expression.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the resultant expression.</returns>
+        public static UnaryExpression PreDecrementAssign(Expression expression) =>
+            new UnaryExpression(ExpressionType.PreDecrementAssign, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents the assignment of the expression followed by a subsequent decrement by 1 of the original expression.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the resultant expression.</returns>
+        public static UnaryExpression PostDecrementAssign(Expression expression) =>
+            new UnaryExpression(ExpressionType.PostDecrementAssign, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents an expression that has a constant value of type Expression.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Quote and the Operand property set to the specified value.</returns>
+        public static UnaryExpression Quote(Expression expression) =>
+            new UnaryExpression(ExpressionType.Quote, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents a unary plus operation.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to UnaryPlus and the Operand property set to the specified value.</returns>
+        public static UnaryExpression UnaryPlus(Expression expression) =>
+            new UnaryExpression(ExpressionType.UnaryPlus, expression, expression.Type);
+
+        /// <summary>Creates a UnaryExpression that represents an explicit unboxing.</summary>
+        /// <param name="expression">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">A Type to set the Type property equal to.</param>
+        /// <returns>A UnaryExpression that has the NodeType property equal to Unbox and the Operand and Type properties set to the specified values.</returns>
+        public static UnaryExpression Unbox(Expression expression, Type type) =>
+            new UnaryExpression(ExpressionType.Unbox, expression, type);
 
         public static Expression<TDelegate> Lambda<TDelegate>(Expression body) =>
             new Expression<TDelegate>(body, Tools.Empty<ParameterExpression>());
@@ -554,6 +667,9 @@ namespace FastExpressionCompiler.LightExpression
         public static CatchBlock Catch(Type test, Expression body) =>
             new CatchBlock(null, body, null, test);
 
+        /// <summary>Creates a UnaryExpression that represents a throwing of an exception.</summary>
+        /// <param name="value">An Expression to set the Operand property equal to.</param>
+        /// <returns>A UnaryExpression that represents the exception.</returns>
         public static UnaryExpression Throw(Expression value) =>
             new UnaryExpression(ExpressionType.Throw, value, typeof(void));
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2379,58 +2379,48 @@ namespace FastExpressionCompiler
                     case ExpressionType.Parameter:
                         var leftParamExpr = (ParameterExpression)left;
                         var paramIndex = paramExprs.GetFirstIndex(leftParamExpr);
+                        var arithmeticNodeType = Tools.GetArithmeticFromArithmeticAssignOrSelf(nodeType);
 
                         if (paramIndex != -1)
                         {
                             // shift parameter indices by one, because the first one will be closure
                             if (closure.HasClosure)
-                                paramIndex += 1; 
+                                paramIndex += 1;
 
                             if (paramIndex >= byte.MaxValue)
                                 return false;
 
                             if (leftParamExpr.IsByRef)
-                            {
                                 EmitLoadParamArg(il, paramIndex, false);
 
-                                var arithmeticNodeType = Tools.GetArithmeticFromArithmeticAssignOrSelf(nodeType);
-                                if (arithmeticNodeType == nodeType)
-                                {
-                                    if (!TryEmit(right, paramExprs, il, ref closure, flags))
-                                        return false;
-                                }
-                                else if (!TryEmitArithmetic(expr, arithmeticNodeType, paramExprs, il, ref closure, parent))
-                                    return false;
-
-                                EmitByRefStore(il, leftParamExpr.Type);
-                            }
-                            else
+                            if (arithmeticNodeType == nodeType)
                             {
                                 if (!TryEmit(right, paramExprs, il, ref closure, flags))
                                     return false;
-
-                                if ((parent & ParentFlags.IgnoreResult) == 0)
-                                    il.Emit(OpCodes.Dup); // dup value to assign and return
-
-                                il.Emit(OpCodes.Starg_S, paramIndex);
                             }
+                            else if (!TryEmitArithmetic(expr, arithmeticNodeType, paramExprs, il, ref closure, parent))
+                                return false;
+
+                            if ((parent & ParentFlags.IgnoreResult) == 0)
+                                il.Emit(OpCodes.Dup); // dup value to assign and return
+
+                            if (leftParamExpr.IsByRef)
+                                EmitByRefStore(il, leftParamExpr.Type);
+                            else
+                                il.Emit(OpCodes.Starg_S, paramIndex);
 
                             return true;
                         }
-                        else
+                        else if (arithmeticNodeType != nodeType)
                         {
-                            var arithmeticNodeType = Tools.GetArithmeticFromArithmeticAssignOrSelf(nodeType);
-                            if (arithmeticNodeType != nodeType)
+                            var varIdx = closure.CurrentBlock.VarExprs.GetFirstIndex(leftParamExpr);
+                            if (varIdx != -1)
                             {
-                                var varIdx = closure.CurrentBlock.VarExprs.GetFirstIndex(leftParamExpr);
-                                if (varIdx != -1)
-                                {
-                                    if (!TryEmitArithmetic(expr, arithmeticNodeType, paramExprs, il, ref closure, parent))
-                                        return false;
+                                if (!TryEmitArithmetic(expr, arithmeticNodeType, paramExprs, il, ref closure, parent))
+                                    return false;
 
-                                    il.Emit(OpCodes.Stloc, closure.CurrentBlock.LocalVars[varIdx]);
-                                    return true;
-                                }
+                                il.Emit(OpCodes.Stloc, closure.CurrentBlock.LocalVars[varIdx]);
+                                return true;
                             }
                         }
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1772,8 +1772,7 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Pop);
                 else
                 {
-                    il.Emit(OpCodes.Ldc_I4_0);
-                    il.Emit(OpCodes.Ceq);
+                    il.Emit(OpCodes.Not);
                 }
                 return true;
             }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1773,7 +1773,15 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Pop);
                 else
                 {
-                    il.Emit(OpCodes.Not);
+                    if (expr.Type == typeof(bool))
+                    {
+                        il.Emit(OpCodes.Ldc_I4_0);
+                        il.Emit(OpCodes.Ceq);
+                    }
+                    else
+                    {
+                        il.Emit(OpCodes.Not);
+                    }
                 }
                 return true;
             }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1319,9 +1319,10 @@ namespace FastExpressionCompiler
                         case ExpressionType.Throw:
                             {
                                 var opExpr = ((UnaryExpression)expr).Operand;
-                                if (!TryEmit(opExpr, paramExprs, il, ref closure, parent))
+                                if (!TryEmit(opExpr, paramExprs, il, ref closure, parent & ~ParentFlags.IgnoreResult))
                                     return false;
-                                il.ThrowException(opExpr.Type);
+
+                                il.Emit(OpCodes.Throw);
                                 return true;
                             }
 

--- a/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
@@ -1,0 +1,610 @@
+﻿using System;
+using NUnit.Framework;
+
+#if LIGHT_EXPRESSION
+using ExpressionType = System.Linq.Expressions.ExpressionType;
+using static FastExpressionCompiler.LightExpression.Expression;
+
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    [TestFixture]
+    public class BinaryExpressionTests
+    {
+        [Test]
+        public void Add_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Add(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void AddAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                AddAssign(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void AddAssignChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                AddAssignChecked(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void AddChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                AddChecked(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void And_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                And(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void AndAlso_compiles()
+        {
+            var param = Parameter(typeof(bool), "b");
+            var expression = Lambda<Func<bool, bool>>(
+                AndAlso(param, Constant(false)),
+                param);
+
+            bool result = expression.CompileFast()(true);
+
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void AndAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                AndAssign(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void ArrayIndex_compiles()
+        {
+            var param = Parameter(typeof(string[]), "s");
+            var expression = Lambda<Func<string[], string>>(
+                ArrayIndex(param, Constant(1)),
+                param);
+
+            string result = expression.CompileFast()(new[] { "1", "2" });
+
+            Assert.AreEqual("2", result);
+        }
+
+        [Test]
+        public void Assign_compiles()
+        {
+            var param = Parameter(typeof(string), "s");
+            var expression = Lambda<Func<string, string>>(
+                Assign(param, Constant("test")),
+                param);
+
+            string result = expression.CompileFast()("original");
+
+            Assert.AreEqual("test", result);
+        }
+
+        [Test]
+        public void Coalesce_compiles()
+        {
+            var param = Parameter(typeof(string), "s");
+            var expression = Lambda<Func<string, string>>(
+                Coalesce(param, Constant("<null>")),
+                param);
+
+            string result = expression.CompileFast()(null);
+
+            Assert.AreEqual("<null>", result);
+        }
+
+        [Test]
+        public void Divide_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Divide(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(6);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void DivideAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                DivideAssign(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(6);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void Equal_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, bool>>(
+                Equal(param, Constant(1, typeof(object))),
+                param);
+
+            bool result = expression.CompileFast()(1);
+
+            // Verify that when passed a boxed value, object.Equals was called
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void ExclusiveOr_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                ExclusiveOr(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void ExclusiveOrAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                ExclusiveOrAssign(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void GreaterThan_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                GreaterThan(param, Constant(2)),
+                param);
+
+            bool result = expression.CompileFast()(3);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void GreaterThanOrEqual_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                GreaterThanOrEqual(param, Constant(2)),
+                param);
+
+            bool result = expression.CompileFast()(2);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void LeftShift_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                LeftShift(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(12, result);
+        }
+
+        [Test]
+        public void LeftShiftAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                LeftShiftAssign(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(12, result);
+        }
+
+        [Test]
+        public void LessThan_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                LessThan(param, Constant(2)),
+                param);
+
+            bool result = expression.CompileFast()(1);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void LessThanOrEqual_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                LessThanOrEqual(param, Constant(2)),
+                param);
+
+            bool result = expression.CompileFast()(2);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MakeBinary_Add_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                MakeBinary(ExpressionType.Add, param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void MakeBinary_ArrayIndex_compiles()
+        {
+            var param = Parameter(typeof(string[]), "s");
+            var expression = Lambda<Func<string[], string>>(
+                MakeBinary(ExpressionType.ArrayIndex, param, Constant(1)),
+                param);
+
+            string result = expression.CompileFast()(new[] { "1", "2" });
+
+            Assert.AreEqual("2", result);
+        }
+
+        [Test]
+        public void MakeBinary_Assign_compiles()
+        {
+            var param = Parameter(typeof(string), "s");
+            var expression = Lambda<Func<string, string>>(
+                MakeBinary(ExpressionType.Assign, param, Constant("test")),
+                param);
+
+            string result = expression.CompileFast()("original");
+
+            Assert.AreEqual("test", result);
+        }
+
+        [Test]
+        public void MakeBinary_Coalesce_compiles()
+        {
+            var param = Parameter(typeof(string), "s");
+            var expression = Lambda<Func<string, string>>(
+                MakeBinary(ExpressionType.Coalesce, param, Constant("<null>")),
+                param);
+
+            string result = expression.CompileFast()(null);
+
+            Assert.AreEqual("<null>", result);
+        }
+
+        [Test]
+        public void Modulo_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Modulo(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void ModuloAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                ModuloAssign(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void Multiply_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Multiply(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void MultiplyAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                MultiplyAssign(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void MultiplyAssignChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                MultiplyAssignChecked(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void MultiplyChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                MultiplyChecked(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(6, result);
+        }
+
+        [Test]
+        public void NotEqual_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, bool>>(
+                NotEqual(param, Constant(1, typeof(object))),
+                param);
+
+            bool result = expression.CompileFast()(2);
+
+            // Verify that when passed a boxed value, object.Equals was called
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Or_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Or(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(7, result);
+        }
+
+        [Test]
+        public void OrAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                OrAssign(param, Constant(3)),
+                param);
+
+            int result = expression.CompileFast()(5);
+
+            Assert.AreEqual(7, result);
+        }
+
+        [Test]
+        public void OrElse_compiles()
+        {
+            var param = Parameter(typeof(bool), "b");
+            var expression = Lambda<Func<bool, bool>>(
+                OrElse(param, Constant(true)),
+                param);
+
+            bool result = expression.CompileFast()(false);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void Power_compiles()
+        {
+            var param = Parameter(typeof(double), "d");
+            var expression = Lambda<Func<double, double>>(
+                Power(param, Constant(2.0)),
+                param);
+
+            double result = expression.CompileFast()(3.0);
+
+            Assert.AreEqual(9.0, result);
+        }
+
+        [Test]
+        public void PowerAssign_compiles()
+        {
+            var param = Parameter(typeof(double), "d");
+            var expression = Lambda<Func<double, double>>(
+                PowerAssign(param, Constant(2.0)),
+                param);
+
+            double result = expression.CompileFast()(3.0);
+
+            Assert.AreEqual(9.0, result);
+        }
+
+        [Test]
+        public void ReferenceEqual_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, bool>>(
+                ReferenceEqual(param, Constant(1, typeof(object))),
+                param);
+
+            bool result = expression.CompileFast()(1);
+
+            // Verify it did a reference equality, which will be comparing boxed
+            // values and, therefore, return false
+            Assert.IsFalse(result);
+        }
+
+        [Test]
+        public void ReferenceNotEqual_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, bool>>(
+                ReferenceNotEqual(param, Constant(1, typeof(object))),
+                param);
+
+            bool result = expression.CompileFast()(1);
+
+            // Verify it did a reference equality, which will be comparing boxed
+            // values and, therefore, return true
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void RightShift_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                RightShift(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(12);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void RightShiftAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                RightShiftAssign(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(12);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void Subtract_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Subtract(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void SubtractAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                SubtractAssign(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void SubtractAssignChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                SubtractAssignChecked(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void SubtractChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                SubtractChecked(param, Constant(2)),
+                param);
+
+            int result = expression.CompileFast()(3);
+
+            Assert.AreEqual(1, result);
+        }
+    }
+}

--- a/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
@@ -175,14 +175,13 @@ namespace FastExpressionCompiler.UnitTests
         [Test]
         public void Equal_compiles()
         {
-            var param = Parameter(typeof(object), "o");
-            var expression = Lambda<Func<object, bool>>(
-                Equal(param, Constant(1, typeof(object))),
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                Equal(param, Constant(1)),
                 param);
 
             bool result = expression.CompileFast()(1);
 
-            // Verify that when passed a boxed value, object.Equals was called
             Assert.IsTrue(result);
         }
 
@@ -423,15 +422,14 @@ namespace FastExpressionCompiler.UnitTests
         [Test]
         public void NotEqual_compiles()
         {
-            var param = Parameter(typeof(object), "o");
-            var expression = Lambda<Func<object, bool>>(
-                NotEqual(param, Constant(1, typeof(object))),
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, bool>>(
+                NotEqual(param, Constant(1)),
                 param);
 
-            bool result = expression.CompileFast()(2);
+            bool result = expression.CompileFast()(1);
 
-            // Verify that when passed a boxed value, object.Equals was called
-            Assert.IsTrue(result);
+            Assert.IsFalse(result);
         }
 
         [Test]
@@ -502,31 +500,29 @@ namespace FastExpressionCompiler.UnitTests
         [Test]
         public void ReferenceEqual_compiles()
         {
+            const string Value = "test";
             var param = Parameter(typeof(object), "o");
             var expression = Lambda<Func<object, bool>>(
-                ReferenceEqual(param, Constant(1, typeof(object))),
+                ReferenceEqual(param, Constant(Value)),
                 param);
 
-            bool result = expression.CompileFast()(1);
+            bool result = expression.CompileFast()(Value);
 
-            // Verify it did a reference equality, which will be comparing boxed
-            // values and, therefore, return false
-            Assert.IsFalse(result);
+            Assert.IsTrue(result);
         }
 
         [Test]
         public void ReferenceNotEqual_compiles()
         {
+            const string Value = "test";
             var param = Parameter(typeof(object), "o");
             var expression = Lambda<Func<object, bool>>(
-                ReferenceNotEqual(param, Constant(1, typeof(object))),
+                ReferenceNotEqual(param, Constant(Value)),
                 param);
 
-            bool result = expression.CompileFast()(1);
+            bool result = expression.CompileFast()(Value);
 
-            // Verify it did a reference equality, which will be comparing boxed
-            // values and, therefore, return true
-            Assert.IsTrue(result);
+            Assert.IsFalse(result);
         }
 
         [Test]

--- a/test/FastExpressionCompiler.UnitTests/ConvertOperatorsTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/ConvertOperatorsTests.cs
@@ -60,20 +60,6 @@ namespace FastExpressionCompiler.UnitTests
             f("hey");
         }
 
-        [Test]
-        public void Target_type_as_in_func()
-        {
-            var sExpr = Parameter(typeof(object), "o");
-            var expr = Lambda<Func<object, string>>(
-                TypeAs(sExpr, typeof(string)),
-                sExpr);
-
-            var f = expr.CompileFast();
-            string result = f("123");
-
-            Assert.AreEqual("123", result);
-        }
-
         public struct X
         {
             public static implicit operator X(string s) => new X("X:" + s);

--- a/test/FastExpressionCompiler.UnitTests/UnaryExpressionTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/UnaryExpressionTests.cs
@@ -1,0 +1,293 @@
+﻿using System;
+using NUnit.Framework;
+
+#if LIGHT_EXPRESSION
+using ExpressionType = System.Linq.Expressions.ExpressionType;
+using static FastExpressionCompiler.LightExpression.Expression;
+
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    [TestFixture]
+    public class UnaryExpressionTests
+    {
+        [Test]
+        public void ArrayLength_compiles()
+        {
+            var param = Parameter(typeof(int[]), "i");
+            var expression = Lambda<Func<int[], int>>(
+                ArrayLength(param),
+                param);
+
+            int result = expression.CompileFast()(new[] { 1, 2, 3 });
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void Convert_compiles()
+        {
+            var param = Parameter(typeof(double), "d");
+            var expression = Lambda<Func<double, int>>(
+                Convert(param, typeof(int)),
+                param);
+
+            int result = expression.CompileFast()(1.5);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void ConvertChecked_compiles()
+        {
+            var param = Parameter(typeof(double), "d");
+            var expression = Lambda<Func<double, int>>(
+                ConvertChecked(param, typeof(int)),
+                param);
+
+            int result = expression.CompileFast()(1.5);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void Decrement_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Decrement(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void Increment_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Increment(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void IsFalse_compiles()
+        {
+            var param = Parameter(typeof(bool), "b");
+            var expression = Lambda<Func<bool, bool>>(
+                IsFalse(param),
+                param);
+
+            bool result = expression.CompileFast()(false);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void IsTrue_compiles()
+        {
+            var param = Parameter(typeof(bool), "b");
+            var expression = Lambda<Func<bool, bool>>(
+                IsTrue(param),
+                param);
+
+            bool result = expression.CompileFast()(true);
+
+            Assert.IsTrue(result);
+        }
+
+        [Test]
+        public void MakeUnary_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                MakeUnary(ExpressionType.Increment, param, null),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void Negate_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Negate(param),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(-1, result);
+        }
+
+        [Test]
+        public void NegateChecked_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                NegateChecked(param),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(-1, result);
+        }
+
+        [Test]
+        public void Not_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                Not(param),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(-2, result);
+        }
+
+        [Test]
+        public void OnesComplement_compiles()
+        {
+            var param = Parameter(typeof(uint), "i");
+            var expression = Lambda<Func<uint, uint>>(
+                OnesComplement(param),
+                param);
+
+            uint result = expression.CompileFast()(0xFFFF0000);
+
+            Assert.AreEqual(0x0000FFFF, result);
+        }
+
+        [Test]
+        public void PostDecrementAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                PostDecrementAssign(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void PostIncrementAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                PostIncrementAssign(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void PreDecrementAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                PreDecrementAssign(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void PreIncrementAssign_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                PreIncrementAssign(param),
+                param);
+
+            int result = expression.CompileFast()(2);
+
+            Assert.AreEqual(3, result);
+        }
+
+        [Test]
+        public void Quote_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, Expression<Func<int>>>>(
+                Quote(Lambda(param)),
+                param);
+
+            var resultExpression = expression.CompileFast()(2);
+            int result = resultExpression.CompileFast()();
+
+            Assert.AreEqual(2, result);
+        }
+
+        [Test]
+        public void Throw_compiles()
+        {
+            var param = Parameter(typeof(Exception), "e");
+            var expression = Lambda<Action<Exception>>(
+                Throw(param),
+                param);
+
+            Action<Exception> result = expression.CompileFast();
+
+            Assert.Throws<DivideByZeroException>(() => result(new DivideByZeroException()));
+        }
+
+        [Test]
+        public void TypeAs_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, string>>(
+                TypeAs(param, typeof(string)),
+                param);
+
+            string result = expression.CompileFast()("123");
+
+            Assert.AreEqual("123", result);
+        }
+
+        [Test]
+        public void UnaryPlus_compiles()
+        {
+            var param = Parameter(typeof(int), "i");
+            var expression = Lambda<Func<int, int>>(
+                UnaryPlus(param),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(1, result);
+        }
+
+        [Test]
+        public void Unbox_compiles()
+        {
+            var param = Parameter(typeof(object), "o");
+            var expression = Lambda<Func<object, int>>(
+                Unbox(param, typeof(int)),
+                param);
+
+            int result = expression.CompileFast()(1);
+
+            Assert.AreEqual(1, result);
+        }
+    }
+}

--- a/test/FastExpressionCompiler.UnitTests/UnaryExpressionTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/UnaryExpressionTests.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using NUnit.Framework;
+using SysExpr = System.Linq.Expressions;
 
 #if LIGHT_EXPRESSION
 using ExpressionType = System.Linq.Expressions.ExpressionType;
@@ -228,12 +229,12 @@ namespace FastExpressionCompiler.UnitTests
         public void Quote_compiles()
         {
             var param = Parameter(typeof(int), "i");
-            var expression = Lambda<Func<int, Expression<Func<int>>>>(
+            var expression = Lambda<Func<int, SysExpr.Expression<Func<int>>>>(
                 Quote(Lambda(param)),
                 param);
 
             var resultExpression = expression.CompileFast()(2);
-            int result = resultExpression.CompileFast()();
+            int result = resultExpression.Compile()();
 
             Assert.AreEqual(2, result);
         }


### PR DESCRIPTION
I've added some methods to the LightExpressions to hopefully aid people porting code over. When adding the tests I found some differences with `Compile` and `CompileFast` so hopefully they're fixed now (namely, `Not` wasn't working for non boolean types, `Throw` didn't throw the exception created by the expression and assignment operators didn't seem to work when assigning to a parameter.

I've also added documentation from MSDN (it's under a Creative Commons license, so I don't think there's a problem with that) - happy to remove if you think it's adding clutter.

One thing I noticed, especially with the `UnaryExpressions`, is a lot of the unit tests are falling back to the native framework version - I wonder if it's worth making the unit tests pass in `true` for `ifFastFailedReturnNull` so that we verify we're not falling back to system expression generation for the simple cases being tested? I would need your help to be honest though changing all of the emitting code.