### PR TITLE
Support for member inc- dec-assignments, re: #181

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2773,7 +2773,7 @@ namespace FastExpressionCompiler
                     }
 
                     closure.LastEmitIsAddress = false;
-                    return EmitMethodCall(il, ((PropertyInfo)expr.Member).FindPropertyGetMethod());
+                    return EmitMethodCall(il, prop.FindPropertyGetMethod());
                 }
 
                 var field = expr.Member as FieldInfo;

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2402,7 +2402,7 @@ namespace FastExpressionCompiler
                     if (!TryEmitMemberAccess(memberAccess, paramExprs, il, ref closure, parent | ParentFlags.DupMemberOwner))
                         return false;
 
-                    useLocalVar = (memberAccess.Expression != null) && (usesResult || memberAccess.Member.MemberType == MemberTypes.Property);
+                    useLocalVar = (memberAccess.Expression != null) && (usesResult || memberAccess.Member is PropertyInfo);
                     localVar = useLocalVar ? il.DeclareLocal(expr.Operand.Type) : null;
                 }
                 else

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -67,10 +67,10 @@ namespace FastExpressionCompiler.UnitTests
 
             var del = lambda.CompileFast();
 
-            var expectedValue = CounterField + 1;
+            var expectedValue = CounterProperty + 1;
             del.Invoke(this);
 
-            Assert.AreEqual(expectedValue, CounterField);
+            Assert.AreEqual(expectedValue, CounterProperty);
         }
 
         [Test]

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -159,5 +159,24 @@ namespace FastExpressionCompiler.UnitTests
 
             Assert.AreEqual(expectedValue, CounterField);
         }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PostIncrement_Field_Func()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+                PostIncrementAssign(
+                    Field(p, nameof(CounterField))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var startValue = CounterField;
+
+            Assert.AreEqual(startValue, del.Invoke(this));
+            Assert.AreEqual(startValue + 1, CounterField);
+        }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -10,8 +10,6 @@ using static System.Linq.Expressions.Expression;
 namespace FastExpressionCompiler.UnitTests
 #endif
 {
-    using System.Reflection.Emit;
-
     public class Issue181_TryEmitIncDecAssign_InvalidCastException
     {
         // originally seen in a Rezolver example, which I've tried to replicate as close as possible
@@ -32,31 +30,6 @@ namespace FastExpressionCompiler.UnitTests
         [Test]
         public void TryEmitIncDecAssign_Supports_PreIncrement_Property_Action()
         {
-            //var method = new DynamicMethod(
-            //    string.Empty,
-            //    typeof(void),
-            //    new[] { typeof(Issue181_TryEmitIncDecAssign_InvalidCastException) },
-            //    typeof(ExpressionCompiler),
-            //    skipVisibility: true);
-
-            //var il = method.GetILGenerator();
-
-            //var field = typeof(Issue181_TryEmitIncDecAssign_InvalidCastException).GetField("CounterField");
-
-            //il.Emit(OpCodes.Ldarg_0);
-            //il.Emit(OpCodes.Dup);
-            //il.Emit(OpCodes.Ldfld, field);
-            //il.Emit(OpCodes.Ldc_I4_1);
-            //il.Emit(OpCodes.Add);
-            //il.Emit(OpCodes.Stfld, field);
-            //il.Emit(OpCodes.Ret);
-
-            //var @delegate = method.CreateDelegate(typeof(Action<Issue181_TryEmitIncDecAssign_InvalidCastException>), null);
-
-            //var func = (Action<Issue181_TryEmitIncDecAssign_InvalidCastException>)@delegate;
-
-            //func.Invoke(this);
-
             var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
 
             var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
@@ -71,6 +44,25 @@ namespace FastExpressionCompiler.UnitTests
             del.Invoke(this);
 
             Assert.AreEqual(expectedValue, CounterProperty);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreIncrement_Nested_Property_Action()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PreIncrementAssign(
+                    Property(Field(p, nameof(CounterObjField)), nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterObjField.CounterProperty + 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterObjField.CounterProperty);
         }
 
         [Test]

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -10,26 +10,105 @@ using static System.Linq.Expressions.Expression;
 namespace FastExpressionCompiler.UnitTests
 #endif
 {
+    using System.Reflection.Emit;
+
     public class Issue181_TryEmitIncDecAssign_InvalidCastException
     {
         // originally seen in a Rezolver example, which I've tried to replicate as close as possible
 
-        public int Counter { get; set; } = 1;
+        public int CounterProperty { get; set; } = 1;
 
+        public int CounterField = 2;
 
-        [Test, Ignore("fixme")]
-        public void TryEmitIncDecAssign_DoesntThrow_InvalidCastException()
+        public Counter CounterObjField = new Counter();
+
+        public class Counter
+        {
+            public int CounterProperty { get; set; } = 3;
+
+            public int CounterField = 4;
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreIncrement_Property_Action()
+        {
+            //var method = new DynamicMethod(
+            //    string.Empty,
+            //    typeof(void),
+            //    new[] { typeof(Issue181_TryEmitIncDecAssign_InvalidCastException) },
+            //    typeof(ExpressionCompiler),
+            //    skipVisibility: true);
+
+            //var il = method.GetILGenerator();
+
+            //var field = typeof(Issue181_TryEmitIncDecAssign_InvalidCastException).GetField("CounterField");
+
+            //il.Emit(OpCodes.Ldarg_0);
+            //il.Emit(OpCodes.Dup);
+            //il.Emit(OpCodes.Ldfld, field);
+            //il.Emit(OpCodes.Ldc_I4_1);
+            //il.Emit(OpCodes.Add);
+            //il.Emit(OpCodes.Stfld, field);
+            //il.Emit(OpCodes.Ret);
+
+            //var @delegate = method.CreateDelegate(typeof(Action<Issue181_TryEmitIncDecAssign_InvalidCastException>), null);
+
+            //var func = (Action<Issue181_TryEmitIncDecAssign_InvalidCastException>)@delegate;
+
+            //func.Invoke(this);
+
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PreIncrementAssign(
+                    Property(p, nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterField + 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterField);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreIncrement_Field_Action()
         {
             var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
 
-            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
                 PreIncrementAssign(
-                    Property(p, nameof(Counter))
+                    Field(p, nameof(CounterField))
                 ),
                 p);
- 
+
             var del = lambda.CompileFast();
-            Assert.AreEqual(Counter + 1, del.Invoke(this));
+
+            var expectedValue = CounterField + 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterField);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreIncrement_Nested_Field_Action()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PreIncrementAssign(
+                    Field(Field(p, nameof(CounterObjField)), nameof(CounterField))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterObjField.CounterField + 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterObjField.CounterField);
         }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -161,6 +161,22 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        public void TryEmitIncDecAssign_Supports_PreIncrement_Nested_Property_Func()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+                PreIncrementAssign(
+                    Property(Field(p, nameof(CounterObjField)), nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            Assert.AreEqual(CounterObjField.CounterProperty + 1, del.Invoke(this));
+        }
+
+        [Test]
         public void TryEmitIncDecAssign_Supports_PostIncrement_Field_Func()
         {
             var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
@@ -177,6 +193,41 @@ namespace FastExpressionCompiler.UnitTests
 
             Assert.AreEqual(startValue, del.Invoke(this));
             Assert.AreEqual(startValue + 1, CounterField);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreDecrement_Property_Func()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+                PreDecrementAssign(
+                    Property(p, nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            Assert.AreEqual(CounterProperty - 1, del.Invoke(this));
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PostDecrement_Nested_Field_Func()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Func<Issue181_TryEmitIncDecAssign_InvalidCastException, int>>(
+                PostDecrementAssign(
+                    Field(Field(p, nameof(CounterObjField)), nameof(CounterField))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var startValue = CounterObjField.CounterField;
+
+            Assert.AreEqual(startValue, del.Invoke(this));
+            Assert.AreEqual(startValue - 1, CounterObjField.CounterField);
         }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -102,5 +102,62 @@ namespace FastExpressionCompiler.UnitTests
 
             Assert.AreEqual(expectedValue, CounterObjField.CounterField);
         }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PostIncrement_Property_Action()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PostIncrementAssign(
+                    Property(p, nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterProperty + 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterProperty);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PreDecrement_Nested_Property_Action()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PreDecrementAssign(
+                    Property(Field(p, nameof(CounterObjField)), nameof(CounterProperty))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterObjField.CounterProperty - 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterObjField.CounterProperty);
+        }
+
+        [Test]
+        public void TryEmitIncDecAssign_Supports_PostDecrement_Field_Action()
+        {
+            var p = Parameter(typeof(Issue181_TryEmitIncDecAssign_InvalidCastException));
+
+            var lambda = Lambda<Action<Issue181_TryEmitIncDecAssign_InvalidCastException>>(
+                PostDecrementAssign(
+                    Field(p, nameof(CounterField))
+                ),
+                p);
+
+            var del = lambda.CompileFast();
+
+            var expectedValue = CounterField - 1;
+            del.Invoke(this);
+
+            Assert.AreEqual(expectedValue, CounterField);
+        }
     }
 }


### PR DESCRIPTION
- Support and test coverage for pre- and post-inc and -dec assignment of instance and static fields and properties
- Forcing emit of member-owning parameters in `TryEmitMemberAccess`
- Support for static field assignment in `EmitMemberAssign`

Fixes #181 

Cheers! :)

Steve