### PR TITLE
Goto expression values support

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -760,7 +760,7 @@ namespace FastExpressionCompiler.LightExpression
             new SimpleBinaryExpression(ExpressionType.NotEqual, left, right, typeof(bool));
 
         public static GotoExpression Return(LabelTarget target, Expression value = null, Type type = null) =>
-            MakeGoto(GotoExpressionKind.Return, target, value);
+            MakeGoto(GotoExpressionKind.Return, target, value, type);
 
         public static GotoExpression Goto(LabelTarget target, Expression value = null, Type type = null) =>
             MakeGoto(GotoExpressionKind.Goto, target, value, type);

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -688,8 +688,14 @@ namespace FastExpressionCompiler.LightExpression
         /// <summary>Creates a UnaryExpression that represents a throwing of an exception.</summary>
         /// <param name="value">An Expression to set the Operand property equal to.</param>
         /// <returns>A UnaryExpression that represents the exception.</returns>
-        public static UnaryExpression Throw(Expression value) =>
-            new UnaryExpression(ExpressionType.Throw, value, typeof(void));
+        public static UnaryExpression Throw(Expression value) => Throw(value, typeof(void));
+
+        /// <summary>Creates a UnaryExpression that represents a throwing of an exception with a given type.</summary>
+        /// <param name="value">An Expression to set the Operand property equal to.</param>
+        /// <param name="type">The Type of the expression.</param>
+        /// <returns>A UnaryExpression that represents the exception.</returns>
+        public static UnaryExpression Throw(Expression value, Type type) =>
+            new UnaryExpression(ExpressionType.Throw, value, type);
 
         public static LabelExpression Label(LabelTarget target, Expression defaultValue = null) =>
             new LabelExpression(target, defaultValue);

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -282,7 +282,6 @@ namespace FastExpressionCompiler.LightExpression
         public static UnaryExpression OnesComplement(Expression expression) =>
             new UnaryExpression(ExpressionType.OnesComplement, expression, expression.Type);
 
-
         /// <summary>Creates a UnaryExpression that increments the expression by 1 and assigns the result back to the expression.</summary>
         /// <param name="expression">An Expression to set the Operand property equal to.</param>
         /// <returns>A UnaryExpression that represents the resultant expression.</returns>
@@ -734,7 +733,6 @@ namespace FastExpressionCompiler.LightExpression
                     return new SimpleBinaryExpression(binaryType, left, right, left.Type);
             }
         }
-
 
         public static GotoExpression MakeGoto(GotoExpressionKind kind, LabelTarget target, Expression value, Type type = null) =>
             new GotoExpression(kind, target, value, type ?? typeof(void));

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2494,8 +2494,6 @@ namespace FastExpressionCompiler
                 var right = expr.Right;
                 var leftNodeType = expr.Left.NodeType;
                 var nodeType = expr.NodeType;
-                var assignFromLocalVar = right.NodeType == ExpressionType.Try;
-                var resultLocalVar = assignFromLocalVar ? il.DeclareLocal(right.Type) : null;
 
                 // if this assignment is part of a single body-less expression or the result of a block
                 // we should put its result to the evaluation stack before the return, otherwise we are
@@ -2632,8 +2630,8 @@ namespace FastExpressionCompiler
                         return true;
 
                     case ExpressionType.MemberAccess:
-                        var memberExpr = (MemberExpression)left;
-                        var member = memberExpr.Member;
+                        var assignFromLocalVar = right.NodeType == ExpressionType.Try;
+                        var resultLocalVar = assignFromLocalVar ? il.DeclareLocal(right.Type) : null;
 
                         if (assignFromLocalVar)
                         {
@@ -2643,6 +2641,7 @@ namespace FastExpressionCompiler
                             il.Emit(OpCodes.Stloc, resultLocalVar);
                         }
 
+                        var memberExpr = (MemberExpression)left;
                         var objExpr = memberExpr.Expression;
                         if (objExpr != null && !TryEmit(objExpr, paramExprs, il, ref closure, flags | ParentFlags.MemberAccess | ParentFlags.InstanceAccess))
                             return false;
@@ -2652,6 +2651,7 @@ namespace FastExpressionCompiler
                         else if (!TryEmit(right, paramExprs, il, ref closure, ParentFlags.Empty))
                             return false;
 
+                        var member = memberExpr.Member;
                         if ((parent & ParentFlags.IgnoreResult) != 0)
                             return EmitMemberAssign(il, member);
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1454,7 +1454,12 @@ namespace FastExpressionCompiler
                 {
                     case GotoExpressionKind.Break:
                     case GotoExpressionKind.Continue:
+                        return EmitGotoLabel(OpCodes.Br, index, il, ref closure);
+
                     case GotoExpressionKind.Goto:
+                        if (expr.Value != null)
+                            goto case GotoExpressionKind.Return;
+
                         return EmitGotoLabel(OpCodes.Br, index, il, ref closure);
 
                     case GotoExpressionKind.Return:
@@ -3507,8 +3512,14 @@ namespace FastExpressionCompiler
                 if (!TryEmit(ifTrueExpr, paramExprs, il, ref closure, parent & ParentFlags.IgnoreResult))
                     return false;
 
-                var labelDone = il.DefineLabel();
                 var ifFalseExpr = expr.IfFalse;
+                if ((ifFalseExpr.NodeType == ExpressionType.Default) && (ifFalseExpr.Type == typeof(void)))
+                {
+                    il.MarkLabel(labelIfFalse);
+                    return true;
+                }
+
+                var labelDone = il.DefineLabel();
 
                 il.Emit(OpCodes.Br, labelDone);
 

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -375,7 +375,7 @@ namespace FastExpressionCompiler
             public FieldInfo[] ClosureFields;
 
             // Helper to decide whether we are inside the block or not
-            public BlockInfo CurrentBlock;
+            private BlockInfo _currentBlock;
 
             // Dictionary for the used Labels in IL
             private KeyValuePair<LabelTarget, Label?>[] _labels;
@@ -389,7 +389,7 @@ namespace FastExpressionCompiler
                 NonPassedParameters = Tools.Empty<ParameterExpression>();
                 NestedLambdas = Tools.Empty<NestedLambdaInfo>();
                 NestedLambdaExprs = Tools.Empty<LambdaExpression>();
-                CurrentBlock = BlockInfo.Empty;
+                _currentBlock = BlockInfo.Empty;
                 _labels = null;
                 LastEmitIsAddress = false;
 
@@ -542,7 +542,7 @@ namespace FastExpressionCompiler
             }
 
             public void PushBlock(IReadOnlyList<ParameterExpression> blockVarExprs, LocalBuilder[] localVars) =>
-                CurrentBlock = new BlockInfo(CurrentBlock, blockVarExprs, localVars);
+                _currentBlock = new BlockInfo(_currentBlock, blockVarExprs, localVars);
 
             public void PushBlockAndConstructLocalVars(IReadOnlyList<ParameterExpression> blockVarExprs, ILGenerator il)
             {
@@ -558,19 +558,19 @@ namespace FastExpressionCompiler
             }
 
             public void PopBlock() =>
-                CurrentBlock = CurrentBlock.Parent;
+                _currentBlock = _currentBlock.Parent;
 
             public bool IsLocalVar(object varParamExpr)
             {
                 var i = -1;
-                for (var block = CurrentBlock; i == -1 && !block.IsEmpty; block = block.Parent)
+                for (var block = _currentBlock; i == -1 && !block.IsEmpty; block = block.Parent)
                     i = block.VarExprs.GetFirstIndex(varParamExpr);
                 return i != -1;
             }
 
             public LocalBuilder GetDefinedLocalVarOrDefault(ParameterExpression varParamExpr)
             {
-                for (var block = CurrentBlock; !block.IsEmpty; block = block.Parent)
+                for (var block = _currentBlock; !block.IsEmpty; block = block.Parent)
                 {
                     if (block.LocalVars.Length == 0)
                         continue;

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1641,9 +1641,6 @@ namespace FastExpressionCompiler
                         il.Emit(OpCodes.Stloc_S, exVar);
                     }
 
-                    //if (isNonVoid)
-                    //    il.Emit(OpCodes.Pop);
-
                     if (!TryEmit(catchBlock.Body, paramExprs, il, ref closure, parent))
                         return false;
 

--- a/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue181_TryEmitIncDecAssign_InvalidCastException.cs
@@ -44,7 +44,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterProperty + 1;
             del.Invoke(this);
@@ -63,7 +65,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterObjField.CounterProperty + 1;
             del.Invoke(this);
@@ -82,7 +86,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterField + 1;
             del.Invoke(this);
@@ -101,7 +107,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterObjField.CounterField + 1;
             del.Invoke(this);
@@ -120,7 +128,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterProperty + 1;
             del.Invoke(this);
@@ -139,7 +149,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterObjField.CounterProperty - 1;
             del.Invoke(this);
@@ -158,7 +170,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var expectedValue = CounterField - 1;
             del.Invoke(this);
@@ -177,8 +191,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
 
+            Assert.IsNotNull(del);
             Assert.AreEqual(CounterObjField.CounterProperty + 1, del.Invoke(this));
         }
 
@@ -193,7 +208,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var startValue = CounterField;
 
@@ -212,7 +229,9 @@ namespace FastExpressionCompiler.UnitTests
                     Field(null, staticField)
                 ));
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var startValue = CounterFieldStatic;
 
@@ -231,8 +250,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
 
+            Assert.IsNotNull(del);
             Assert.AreEqual(CounterProperty - 1, del.Invoke(this));
         }
 
@@ -247,8 +267,9 @@ namespace FastExpressionCompiler.UnitTests
                     Property(null, staticProperty)
                 ));
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
 
+            Assert.IsNotNull(del);
             Assert.AreEqual(CounterPropertyStatic - 1, del.Invoke());
         }
 
@@ -263,7 +284,9 @@ namespace FastExpressionCompiler.UnitTests
                 ),
                 p);
 
-            var del = lambda.CompileFast();
+            var del = lambda.CompileFast(true);
+
+            Assert.IsNotNull(del);
 
             var startValue = CounterObjField.CounterField;
 

--- a/test/FastExpressionCompiler.IssueTests/Issue78_blocks_with_constant_return.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue78_blocks_with_constant_return.cs
@@ -17,7 +17,7 @@ namespace FastExpressionCompiler.UnitTests
     class Issue78_blocks_with_constant_return
     {
         [Test]
-        public void BlockWithConstanReturnIsSupported()
+        public void BlockWithConstantReturnIsSupported()
         {
             var ret = Block(Label(Label(typeof(int)), Constant(7)));
             var lambda = Lambda<Func<int>>(ret);

--- a/test/FastExpressionCompiler.UnitTests/AssignTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/AssignTests.cs
@@ -45,6 +45,32 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        public void Parameter_test_try_catch_finally_result()
+        {
+            var tryCatchParameter = Variable(typeof(TryCatchTest));
+
+            var assignExpr = Lambda<Func<TryCatchTest, TryCatchTest>>(
+                Block(
+                    Assign(
+                        tryCatchParameter, 
+                        TryCatch(
+                            New(tryCatchParameter.Type.GetConstructor(Type.EmptyTypes)),
+                            Catch(typeof(Exception), Default(tryCatchParameter.Type)))),
+                    tryCatchParameter
+                ),
+                tryCatchParameter);
+
+            var func = assignExpr.CompileFast(true);
+
+            Assert.IsNotNull(func);
+
+            var input = new TryCatchTest();
+            var tryCatchResult = func(input);
+            Assert.AreNotSame(input, tryCatchResult);
+            Assert.IsNotNull(tryCatchResult);
+        }
+
+        [Test]
         public void Member_test_prop()
         {
             var a = new Test();
@@ -223,7 +249,7 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
-        public void Member_test_try_catch_finally_results()
+        public void Member_test_try_catch_finally_result()
         {
             var tryCatchVar = Variable(typeof(TryCatchTest));
             var tryCatchNestedVar = Variable(typeof(TryCatchNestedTest));

--- a/test/FastExpressionCompiler.UnitTests/AssignTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/AssignTests.cs
@@ -124,6 +124,34 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        public void Member_test_block_result()
+        {
+            var testVar = Variable(typeof(Test));
+            var intVar = Variable(typeof(int));
+
+            var assignExpr = Lambda<Func<Test>>(
+                Block(
+                    Assign(testVar, New(testVar.Type.GetConstructor(Type.EmptyTypes))),
+                    Assign(
+                        Property(testVar, nameof(Test.Prop)),
+                        Block(
+                            new[] { intVar },
+                            Assign(intVar, Constant(0)),
+                            PreIncrementAssign(intVar),
+                            PreIncrementAssign(intVar),
+                            intVar)),
+                    testVar));
+
+            var func = assignExpr.CompileFast(true);
+
+            Assert.IsNotNull(func);
+
+            var test = func();
+            Assert.IsNotNull(test);
+            Assert.AreEqual(2, test.Prop);
+        }
+
+        [Test]
         public void Member_test_try_catch_finally_result()
         {
             var tryCatchVar = Variable(typeof(TryCatchTest));

--- a/test/FastExpressionCompiler.UnitTests/GotoTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/GotoTests.cs
@@ -1,0 +1,38 @@
+﻿using System;
+using NUnit.Framework;
+
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    [TestFixture]
+    public class GotoTests
+    {
+        [Test]
+        public void Can_goto_with_value()
+        {
+            var intParameter = Parameter(typeof(int));
+            var returnLabel = Label(typeof(string));
+
+            var expr = Lambda<Func<int, string>>(
+                Block(
+                    IfThen(Equal(intParameter, Constant(10)), Goto(returnLabel, Constant("TEN"))),
+                    IfThen(Equal(intParameter, Constant(5)), Goto(returnLabel, Constant("FIVE"))),
+                    IfThen(Equal(intParameter, Constant(3)), Goto(returnLabel, Constant("THREE"))),
+                    Label(returnLabel, Constant("ZERO"))),
+                intParameter);
+
+            var f = expr.CompileFast(true);
+
+            Assert.IsNotNull(f);
+            Assert.AreEqual("TEN", f(10));
+            Assert.AreEqual("FIVE", f(5));
+            Assert.AreEqual("THREE", f(3));
+            Assert.AreEqual("ZERO", f(1));
+        }
+    }
+}

--- a/test/FastExpressionCompiler.UnitTests/LoopTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/LoopTests.cs
@@ -27,7 +27,9 @@ namespace FastExpressionCompiler.UnitTests
             var lambdaBody = Block(new[] { intVariable }, loop, Label(returnLabel));
 
             var loopLambda = Lambda<Action>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -47,7 +49,9 @@ namespace FastExpressionCompiler.UnitTests
             var loopWithBreak = Loop(loopBody, breakLabel);
 
             var loopLambda = Lambda<Action>(loopWithBreak);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -68,7 +72,9 @@ namespace FastExpressionCompiler.UnitTests
             var lambdaBody = Block(new[] { intVariable }, loop, Label(returnLabel));
 
             var loopLambda = Lambda<Action>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -97,7 +103,9 @@ namespace FastExpressionCompiler.UnitTests
             var lambdaBody = Block(new[] { intVariable1, intVariable2 }, loopWithBreakAndContinue);
 
             var loopLambda = Lambda<Action>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -118,7 +126,9 @@ namespace FastExpressionCompiler.UnitTests
             var lambdaBody = Block(new[] { intVariable }, loop);
 
             var loopLambda = Lambda<Action>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -140,7 +150,9 @@ namespace FastExpressionCompiler.UnitTests
             var lambdaBody = Block(new[] { intVariable }, loop, Label(returnLabel));
 
             var loopLambda = Lambda<Action>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             loopFunc.Invoke();
         }
@@ -149,18 +161,20 @@ namespace FastExpressionCompiler.UnitTests
         public void Loop_with_return_value()
         {
             var intVariable = Variable(typeof(int), "i");
-            var incrementVariable = PreIncrementAssign(intVariable);
+            var assignVariable = Assign(intVariable, Constant(4));
 
             var returnLabel = Label(typeof(int));
 
             var variableMoreThanThree = GreaterThan(intVariable, Constant(3));
             var ifMoreThanThreeReturnFive = IfThen(variableMoreThanThree, Return(returnLabel, Constant(5)));
 
-            var loop = Loop(Block(ifMoreThanThreeReturnFive, incrementVariable));
+            var loop = Loop(Block(assignVariable, ifMoreThanThreeReturnFive));
             var lambdaBody = Block(new[] { intVariable }, loop, Label(returnLabel, Constant(3)));
 
             var loopLambda = Lambda<Func<int>>(lambdaBody);
-            var loopFunc = loopLambda.CompileFast();
+            var loopFunc = loopLambda.CompileFast(true);
+
+            Assert.IsNotNull(loopFunc);
 
             var result = loopFunc.Invoke();
 

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -189,5 +189,73 @@ namespace FastExpressionCompiler.UnitTests
             Assert.IsNotNull(func);
             Assert.AreEqual("From Catch block", func());
         }
+
+        [Test]
+        public void Can_return_try_block_result_using_label()
+        {
+            var returnType = typeof(string);
+            var innerReturnLabel = Label(returnType);
+            var outerReturnLabel = Label(returnType);
+
+            var expr = Lambda<Func<string>>(Block(
+                TryCatch(
+                    Return(
+                        outerReturnLabel,
+                        Block(
+                            TryCatch(
+                                Return(innerReturnLabel, Constant("From inner Try block"), returnType),
+                                Catch(
+                                    typeof(Exception),
+                                    Return(innerReturnLabel, Constant("From inner Catch block"), returnType)
+                                )
+                            ),
+                            Label(innerReturnLabel, Default(innerReturnLabel.Type))),
+                        returnType),
+                    Catch(
+                        typeof(Exception),
+                        Return(outerReturnLabel, Constant("From outer Catch block"), returnType)
+                    )
+                ),
+                Label(outerReturnLabel, Default(outerReturnLabel.Type))));
+
+            var func = expr.CompileFast(true);
+
+            Assert.IsNotNull(func);
+            Assert.AreEqual("From inner Try block", func());
+        }
+
+        [Test]
+        public void Can_return_from_nested_catch_block_using_outer_label()
+        {
+            var returnType = typeof(string);
+            var innerReturnLabel = Label(returnType);
+            var outerReturnLabel = Label(returnType);
+
+            var expr = Lambda<Func<string>>(Block(
+                TryCatch(
+                    Return(
+                        outerReturnLabel,
+                        Block(
+                            TryCatch(
+                                Throw(New(typeof(Exception).GetConstructor(Type.EmptyTypes)), returnType),
+                                Catch(
+                                    typeof(Exception),
+                                    Return(outerReturnLabel, Constant("From inner Catch block"), returnType)
+                                )
+                            ),
+                            Label(innerReturnLabel, Default(innerReturnLabel.Type))),
+                        returnType),
+                    Catch(
+                        typeof(Exception),
+                        Return(outerReturnLabel, Constant("From outer Catch block"), returnType)
+                    )
+                ),
+                Label(outerReturnLabel, Default(outerReturnLabel.Type))));
+
+            var func = expr.CompileFast(true);
+
+            Assert.IsNotNull(func);
+            Assert.AreEqual("From inner Catch block", func());
+        }
     }
 }

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -225,7 +225,7 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
-        public void Can_return_from_nested_catch_block_using_outer_label()
+        public void Can_return_nested_catch_block_result()
         {
             var returnType = typeof(string);
             var innerReturnLabel = Label(returnType);
@@ -240,7 +240,7 @@ namespace FastExpressionCompiler.UnitTests
                                 Throw(New(typeof(Exception).GetConstructor(Type.EmptyTypes)), returnType),
                                 Catch(
                                     typeof(Exception),
-                                    Return(outerReturnLabel, Constant("From inner Catch block"), returnType)
+                                    Return(innerReturnLabel, Constant("From inner Catch block"), returnType)
                                 )
                             ),
                             Label(innerReturnLabel, Default(innerReturnLabel.Type))),

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -164,9 +164,30 @@ namespace FastExpressionCompiler.UnitTests
                 Label(returnLabel, Default(returnLabel.Type))));
 
             var func = expr.CompileFast(true);
-            
+
             Assert.IsNotNull(func);
             Assert.AreEqual("From Try block", func());
+        }
+
+        [Test]
+        public void Can_return_from_catch_block_using_label()
+        {
+            var returnLabel = Label(typeof(string));
+
+            var expr = Lambda<Func<string>>(Block(
+                TryCatch(
+                    Throw(New(typeof(Exception).GetConstructor(Type.EmptyTypes)), typeof(string)),
+                    Catch(
+                        typeof(Exception),
+                        Return(returnLabel, Constant("From Catch block"), typeof(string))
+                    )
+                ),
+                Label(returnLabel, Default(returnLabel.Type))));
+
+            var func = expr.CompileFast(true);
+
+            Assert.IsNotNull(func);
+            Assert.AreEqual("From Catch block", func());
         }
     }
 }

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -12,7 +12,7 @@ using static System.Linq.Expressions.Expression;
 namespace FastExpressionCompiler.UnitTests
 #endif
 {
-[TestFixture]
+    [TestFixture]
     public class TryCatchTests
     {
         [Test]
@@ -20,7 +20,7 @@ namespace FastExpressionCompiler.UnitTests
         {
             var expr = Lambda<Action>(TryCatch(
                     Throw(Constant(new DivideByZeroException())),
-                    Catch(typeof(DivideByZeroException), 
+                    Catch(typeof(DivideByZeroException),
                         Throw(Constant(new InvalidTimeZoneException())
                     )
                 )
@@ -146,6 +146,27 @@ namespace FastExpressionCompiler.UnitTests
 
             Assert.IsNotNull(func);
             Assert.Throws<DivideByZeroException>(() => func());
+        }
+
+        [Test]
+        public void Can_return_from_try_block_using_label()
+        {
+            var returnLabel = Label(typeof(string));
+
+            var expr = Lambda<Func<string>>(Block(
+                TryCatch(
+                    Return(returnLabel, Constant("From Try block"), typeof(string)),
+                    Catch(
+                        typeof(Exception),
+                        Return(returnLabel, Constant("From Catch block"), typeof(string))
+                    )
+                ),
+                Label(returnLabel, Default(returnLabel.Type))));
+
+            var func = expr.CompileFast(true);
+            
+            Assert.IsNotNull(func);
+            Assert.AreEqual("From Try block", func());
         }
     }
 }


### PR DESCRIPTION
Re: #192: 

- Support for Continue, Return and Return value Gotos
- Support for assigning the result of a try/catch to a member
- Extra try/catch and assignment test coverage
- Ensuring FastCompile in Loop and Issue 181 tests
- Removing Leave instructions in `TryEmitTryCatchFinallyBlock` as `il.BeginCatchBlock()` (etc) emits Leave instructions
- Removing unreachable emit of Pop instruction in `TryEmitTryCatchFinallyBlock`