### PR TITLE
Fix performance with try catch tracking

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -1622,7 +1622,8 @@ namespace FastExpressionCompiler.LightExpression
             Test = test;
         }
 
-        internal System.Linq.Expressions.CatchBlock ToCatchBlock() => SysExpr.Catch(Variable.ToParameterExpression(), Body.ToExpression());
+        internal System.Linq.Expressions.CatchBlock ToCatchBlock() => 
+            SysExpr.MakeCatchBlock(Test, Variable?.ToParameterExpression(), Body.ToExpression(), Filter?.ToExpression());
     }
 
     public sealed class LabelExpression : Expression

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -432,7 +432,7 @@ namespace FastExpressionCompiler
             }
         }
 
-        private sealed class TryCatchFinallyInfo
+        private struct TryCatchFinallyInfo
         {
             public bool ContainsReturnGotoExpression;
             public int ReturnLabelIndex;

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -441,15 +441,14 @@ namespace FastExpressionCompiler
 
         private struct TryCatchFinallyInfo
         {
-            public bool HasReturnExpression { get; set; }
-
-            public int ReturnLabelIndex { get; set; }
+            public bool HasReturnExpression;
+            public int ReturnLabelIndex;
         }
 
         // Track the info required to build a closure object + some context information not directly related to closure.
         private struct EmitContext
         {
-            #region Emitting context to track state
+            #region Context to track the emitting state
 
             public bool LastEmitIsAddress;
 
@@ -674,18 +673,20 @@ namespace FastExpressionCompiler
 
             public void PushBlock(IReadOnlyList<ParameterExpression> blockVarExprs)
             {
-                _blockStack = _blockStack.WithLast(new BlockInfo(blockVarExprs));
-                ++_currentBlockIndex;
+                //_blockStack = _blockStack.WithLast(new BlockInfo(blockVarExprs));
+                //++_currentBlockIndex;
             }
 
             public BlockInfo PushAndGetBlock(IReadOnlyList<ParameterExpression> blockVarExprs)
             {
-                if (UserDefinedClosure != null)
-                    PushBlock(blockVarExprs);
-                else
-                    ++_currentBlockIndex;
+                //if (UserDefinedClosure != null)
+                {
+                    _blockStack = _blockStack.WithLast(new BlockInfo(blockVarExprs));
+                }
 
-                return _blockStack[_currentBlockIndex];
+                //++_currentBlockIndex;
+
+                return _blockStack[++_currentBlockIndex];
             }
 
             public void PopBlock() => --_currentBlockIndex;
@@ -1146,13 +1147,13 @@ namespace FastExpressionCompiler
 
                     case ExpressionType.Block:
                         var blockExpr = (BlockExpression)expr;
-                        var blockHasVariables = blockExpr.Variables.Count != 0;
-                        if (blockHasVariables)
-                            closure.PushBlock(blockExpr.Variables);
+                        //var blockHasVariables = blockExpr.Variables.Count != 0;
+                        //if (blockHasVariables)
+                        //    closure.PushBlock(blockExpr.Variables);
                         if (!TryCollectBoundConstants(ref closure, blockExpr.Expressions, paramExprs))
                             return false;
-                        if (blockHasVariables)
-                            closure.PopBlock();
+                        //if (blockHasVariables)
+                            //closure.PopBlock();
                         return true;
 
                     case ExpressionType.Loop:
@@ -1300,7 +1301,7 @@ namespace FastExpressionCompiler
                 var catchExVar = catchBlock.Variable;
                 if (catchExVar != null)
                 {
-                    closure.PushBlock(new[] { catchExVar });
+                    //closure.PushBlock(new[] { catchExVar });
                     if (!TryCollectBoundConstants(ref closure, catchExVar, paramExprs))
                         return false;
                 }
@@ -1311,8 +1312,8 @@ namespace FastExpressionCompiler
                     !TryCollectBoundConstants(ref closure, catchBody, paramExprs))
                     return false;
 
-                if (catchExVar != null)
-                    closure.PopBlock();
+                //if (catchExVar != null)
+                //    closure.PopBlock();
             }
 
             var finallyExpr = tryExpr.Finally;

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -47,8 +47,18 @@ namespace FastExpressionCompiler.Benchmarks
                  CompileFast_WithoutClosure |  10.794 us | 0.0673 us | 0.0562 us |  0.88 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
                 CompileFast_LightExpression |   9.743 us | 0.0676 us | 0.0632 us |  0.79 |    0.01 |      0.7019 |      0.3510 |      0.0305 |             3.26 KB |
  CompileFast_LightExpression_WithoutClosure |   8.571 us | 0.0464 us | 0.0434 us |  0.70 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
-        */
 
+        ## Small memory improvements when changing the `TryCatchFinallyInfo` from class to struct
+
+                                     Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
+                                    Compile | 286.993 us | 1.3492 us | 1.1960 us | 23.14 |    0.16 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  12.410 us | 0.0839 us | 0.0785 us |  1.00 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.23 KB |
+                 CompileFast_WithoutClosure |  10.539 us | 0.0697 us | 0.0652 us |  0.85 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+                CompileFast_LightExpression |   9.698 us | 0.0435 us | 0.0385 us |  0.78 |    0.01 |      0.7019 |      0.3510 |      0.0305 |             3.23 KB |
+ CompileFast_LightExpression_WithoutClosure |   8.948 us | 0.0687 us | 0.0643 us |  0.72 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+ 
+        */
         [MemoryDiagnoser]
         public class Compile_only
         {

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -40,6 +40,9 @@ namespace FastExpressionCompiler.Benchmarks
             public object CompileFast() => _expression.CompileFast();
 
             [Benchmark]
+            public object CompileFast_WithoutClosure() => _expression.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>();
+
+            [Benchmark]
             public object CompileFast_LightExpression() => LightExpression.ExpressionCompiler.CompileFast(_lightExpression);
         }
 

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -20,11 +20,13 @@ namespace FastExpressionCompiler.Benchmarks
           DefaultJob : .NET Core 2.1.11 (CoreCLR 4.6.27617.04, CoreFX 4.6.27617.02), 64bit RyuJIT
 
 
-                              Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
-        ---------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
-                             Compile | 285.788 us | 1.7830 us | 1.6679 us | 22.66 |    0.29 |      1.9531 |      0.9766 |           - |            10.93 KB |
-                         CompileFast |  12.613 us | 0.1554 us | 0.1454 us |  1.00 |    0.00 |      0.7477 |      0.3662 |      0.0305 |             3.44 KB |
-         CompileFast_LightExpression |   9.845 us | 0.0541 us | 0.0451 us |  0.78 |    0.01 |      0.7477 |      0.3662 |      0.0305 |             3.44 KB |
+                                     Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
+                                    Compile | 291.735 us | 3.6419 us | 3.4067 us | 22.30 |    0.31 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  13.104 us | 0.0625 us | 0.0522 us |  1.00 |    0.00 |      0.6866 |      0.3357 |      0.0305 |              3.2 KB |
+                 CompileFast_WithoutClosure |  10.585 us | 0.0809 us | 0.0757 us |  0.81 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+                CompileFast_LightExpression |   9.829 us | 0.0751 us | 0.0666 us |  0.75 |    0.01 |      0.6866 |      0.3357 |      0.0305 |              3.2 KB |
+ CompileFast_LightExpression_WithoutClosure |   9.028 us | 0.0632 us | 0.0560 us |  0.69 |    0.00 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
 
         ## Degradation after adding block / try-catch collection + added WithoutClosure for comparison
 

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -38,15 +38,15 @@ namespace FastExpressionCompiler.Benchmarks
                 CompileFast_LightExpression |  15.243 us | 0.1002 us | 0.0937 us |  0.80 |    0.01 |      0.9918 |      0.4883 |      0.0458 |             4.61 KB |
  CompileFast_LightExpression_WithoutClosure |   3.882 us | 0.0735 us | 0.0787 us |  0.20 |    0.01 |      0.6294 |           - |           - |             2.91 KB |
 
-        ## Got it back a bit
+        ## Fixed the tests and get back some performance
 
                                      Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
 ------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
-                                    Compile | 289.532 us | 1.7909 us | 1.6752 us | 15.95 |    0.21 |      1.9531 |      0.9766 |           - |            10.93 KB |
-                                CompileFast |  18.156 us | 0.2027 us | 0.1896 us |  1.00 |    0.00 |      0.9155 |      0.4578 |      0.0305 |             4.23 KB |
-                 CompileFast_WithoutClosure |  10.596 us | 0.0600 us | 0.0532 us |  0.58 |    0.01 |      0.6866 |      0.3357 |      0.0305 |             3.14 KB |
-                CompileFast_LightExpression |  14.583 us | 0.0815 us | 0.0680 us |  0.80 |    0.01 |      0.9155 |      0.4578 |      0.0458 |             4.23 KB |
- CompileFast_LightExpression_WithoutClosure |   8.888 us | 0.0762 us | 0.0713 us |  0.49 |    0.01 |      0.6866 |      0.3357 |      0.0305 |             3.14 KB |
+                                    Compile | 289.864 us | 2.7638 us | 2.5853 us | 23.65 |    0.25 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  12.262 us | 0.0789 us | 0.0699 us |  1.00 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.26 KB |
+                 CompileFast_WithoutClosure |  10.794 us | 0.0673 us | 0.0562 us |  0.88 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+                CompileFast_LightExpression |   9.743 us | 0.0676 us | 0.0632 us |  0.79 |    0.01 |      0.7019 |      0.3510 |      0.0305 |             3.26 KB |
+ CompileFast_LightExpression_WithoutClosure |   8.571 us | 0.0464 us | 0.0434 us |  0.70 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
         */
 
         [MemoryDiagnoser]
@@ -62,11 +62,11 @@ namespace FastExpressionCompiler.Benchmarks
             public object CompileFast() => _expression.CompileFast();
 
             [Benchmark]
-            public object CompileFast_WithoutClosure() => 
+            public object CompileFast_WithoutClosure() =>
                 _expression.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>();
 
             [Benchmark]
-            public object CompileFast_LightExpression() => 
+            public object CompileFast_LightExpression() =>
                 LightExpression.ExpressionCompiler.CompileFast(_lightExpression);
 
             [Benchmark]

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -35,6 +35,15 @@ namespace FastExpressionCompiler.Benchmarks
                  CompileFast_WithoutClosure |   5.373 us | 0.0222 us | 0.0207 us |  0.28 |    0.00 |      0.6256 |           - |           - |             2.91 KB |
                 CompileFast_LightExpression |  15.243 us | 0.1002 us | 0.0937 us |  0.80 |    0.01 |      0.9918 |      0.4883 |      0.0458 |             4.61 KB |
  CompileFast_LightExpression_WithoutClosure |   3.882 us | 0.0735 us | 0.0787 us |  0.20 |    0.01 |      0.6294 |           - |           - |             2.91 KB |
+
+        ## Got it back a bit
+                                     Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
+                                    Compile | 292.247 us | 2.0617 us | 1.9285 us | 15.18 |    0.09 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  19.261 us | 0.1001 us | 0.0887 us |  1.00 |    0.00 |      0.9460 |      0.4578 |      0.0305 |             4.34 KB |
+                 CompileFast_WithoutClosure |  11.520 us | 0.0803 us | 0.0712 us |  0.60 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.24 KB |
+                CompileFast_LightExpression |  15.705 us | 0.0879 us | 0.0822 us |  0.82 |    0.01 |      0.9460 |      0.4578 |      0.0305 |             4.34 KB |
+ CompileFast_LightExpression_WithoutClosure |   9.457 us | 0.0890 us | 0.0744 us |  0.49 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.24 KB |
         */
 
         [MemoryDiagnoser]

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -37,13 +37,14 @@ namespace FastExpressionCompiler.Benchmarks
  CompileFast_LightExpression_WithoutClosure |   3.882 us | 0.0735 us | 0.0787 us |  0.20 |    0.01 |      0.6294 |           - |           - |             2.91 KB |
 
         ## Got it back a bit
+
                                      Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
 ------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
-                                    Compile | 292.247 us | 2.0617 us | 1.9285 us | 15.18 |    0.09 |      1.9531 |      0.9766 |           - |            10.93 KB |
-                                CompileFast |  19.261 us | 0.1001 us | 0.0887 us |  1.00 |    0.00 |      0.9460 |      0.4578 |      0.0305 |             4.34 KB |
-                 CompileFast_WithoutClosure |  11.520 us | 0.0803 us | 0.0712 us |  0.60 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.24 KB |
-                CompileFast_LightExpression |  15.705 us | 0.0879 us | 0.0822 us |  0.82 |    0.01 |      0.9460 |      0.4578 |      0.0305 |             4.34 KB |
- CompileFast_LightExpression_WithoutClosure |   9.457 us | 0.0890 us | 0.0744 us |  0.49 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.24 KB |
+                                    Compile | 289.532 us | 1.7909 us | 1.6752 us | 15.95 |    0.21 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  18.156 us | 0.2027 us | 0.1896 us |  1.00 |    0.00 |      0.9155 |      0.4578 |      0.0305 |             4.23 KB |
+                 CompileFast_WithoutClosure |  10.596 us | 0.0600 us | 0.0532 us |  0.58 |    0.01 |      0.6866 |      0.3357 |      0.0305 |             3.14 KB |
+                CompileFast_LightExpression |  14.583 us | 0.0815 us | 0.0680 us |  0.80 |    0.01 |      0.9155 |      0.4578 |      0.0458 |             4.23 KB |
+ CompileFast_LightExpression_WithoutClosure |   8.888 us | 0.0762 us | 0.0713 us |  0.49 |    0.01 |      0.6866 |      0.3357 |      0.0305 |             3.14 KB |
         */
 
         [MemoryDiagnoser]

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -25,7 +25,17 @@ namespace FastExpressionCompiler.Benchmarks
                              Compile | 285.788 us | 1.7830 us | 1.6679 us | 22.66 |    0.29 |      1.9531 |      0.9766 |           - |            10.93 KB |
                          CompileFast |  12.613 us | 0.1554 us | 0.1454 us |  1.00 |    0.00 |      0.7477 |      0.3662 |      0.0305 |             3.44 KB |
          CompileFast_LightExpression |   9.845 us | 0.0541 us | 0.0451 us |  0.78 |    0.01 |      0.7477 |      0.3662 |      0.0305 |             3.44 KB |
-         */
+
+        ## Degradation after adding block / try-catch collection + added WithoutClosure for comparison
+
+                                     Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
+                                    Compile | 254.680 us | 1.0914 us | 1.0209 us | 13.38 |    0.13 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  19.031 us | 0.1987 us | 0.1858 us |  1.00 |    0.00 |      0.9766 |      0.4883 |      0.0305 |             4.61 KB |
+                 CompileFast_WithoutClosure |   5.373 us | 0.0222 us | 0.0207 us |  0.28 |    0.00 |      0.6256 |           - |           - |             2.91 KB |
+                CompileFast_LightExpression |  15.243 us | 0.1002 us | 0.0937 us |  0.80 |    0.01 |      0.9918 |      0.4883 |      0.0458 |             4.61 KB |
+ CompileFast_LightExpression_WithoutClosure |   3.882 us | 0.0735 us | 0.0787 us |  0.20 |    0.01 |      0.6294 |           - |           - |             2.91 KB |
+        */
 
         [MemoryDiagnoser]
         public class Compile_only
@@ -40,10 +50,16 @@ namespace FastExpressionCompiler.Benchmarks
             public object CompileFast() => _expression.CompileFast();
 
             [Benchmark]
-            public object CompileFast_WithoutClosure() => _expression.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>();
+            public object CompileFast_WithoutClosure() => 
+                _expression.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>();
 
             [Benchmark]
-            public object CompileFast_LightExpression() => LightExpression.ExpressionCompiler.CompileFast(_lightExpression);
+            public object CompileFast_LightExpression() => 
+                LightExpression.ExpressionCompiler.CompileFast(_lightExpression);
+
+            [Benchmark]
+            public object CompileFast_LightExpression_WithoutClosure() => 
+                LightExpression.ExpressionCompiler.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>(_lightExpression);
         }
 
         /*

--- a/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
+++ b/test/FastExpressionCompiler.Benchmarks/AutoMapper_UseCase_Simplified_OneProperty.cs
@@ -57,6 +57,16 @@ namespace FastExpressionCompiler.Benchmarks
                  CompileFast_WithoutClosure |  10.539 us | 0.0697 us | 0.0652 us |  0.85 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
                 CompileFast_LightExpression |   9.698 us | 0.0435 us | 0.0385 us |  0.78 |    0.01 |      0.7019 |      0.3510 |      0.0305 |             3.23 KB |
  CompileFast_LightExpression_WithoutClosure |   8.948 us | 0.0687 us | 0.0643 us |  0.72 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+
+        ## Removing the recursion where possible in TryCollectBoundConstants, in-lining in some places
+
+                                     Method |       Mean |     Error |    StdDev | Ratio | RatioSD | Gen 0/1k Op | Gen 1/1k Op | Gen 2/1k Op | Allocated Memory/Op |
+------------------------------------------- |-----------:|----------:|----------:|------:|--------:|------------:|------------:|------------:|--------------------:|
+                                    Compile | 285.340 us | 1.8488 us | 1.7294 us | 24.17 |    0.20 |      1.9531 |      0.9766 |           - |            10.93 KB |
+                                CompileFast |  11.804 us | 0.0780 us | 0.0730 us |  1.00 |    0.00 |      0.7019 |      0.3510 |      0.0305 |             3.23 KB |
+                 CompileFast_WithoutClosure |  10.526 us | 0.0959 us | 0.0801 us |  0.89 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
+                CompileFast_LightExpression |   9.652 us | 0.0787 us | 0.0736 us |  0.82 |    0.01 |      0.7019 |      0.3510 |      0.0305 |             3.23 KB |
+ CompileFast_LightExpression_WithoutClosure |   8.686 us | 0.0743 us | 0.0620 us |  0.74 |    0.01 |      0.6714 |      0.3357 |      0.0305 |             3.09 KB |
  
         */
         [MemoryDiagnoser]

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -7,9 +7,9 @@ namespace FastExpressionCompiler.Benchmarks
     {
         public static void Main()
         {
-            //BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Compile_only>();
+            BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Compile_only>();
             //BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Create_and_Compile>();
-            BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Invoke_compiled_delegate>();
+            //BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Invoke_compiled_delegate>();
 
             //BenchmarkRunner.Run<NestedLambdaOverhead>();
 

--- a/test/FastExpressionCompiler.IssueTests/Issue102_Label_and_Goto_Expression.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue102_Label_and_Goto_Expression.cs
@@ -46,8 +46,7 @@ namespace FastExpressionCompiler.UnitTests
 
             Assert.Throws<InvalidOperationException>(() => lambda.CompileSys());
 
-            Assert.Throws<InvalidOperationException>(() =>
-                lambda.CompileFast(true));
+            Assert.Throws<InvalidOperationException>(() => lambda.CompileFast(true));
         }
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue159_NumericConversions.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue159_NumericConversions.cs
@@ -624,19 +624,19 @@ IL_0021:  ret
                 nullableIntHolderParam);
 
             var adapt = adaptExpr.CompileFast();
-            adapt.Method.AssertOpCodes(
-                OpCodes.Newobj,
-                OpCodes.Stloc_0, // todo: can be replaced with dup #
-                OpCodes.Ldloc_0, // 
-                OpCodes.Ldarg_0,
-                OpCodes.Call, // ValueHolder<int?>.get_Value
-                OpCodes.Stloc_1,
-                OpCodes.Ldloca_S,
-                OpCodes.Call, // int?.get_Value
-                OpCodes.Conv_R8,
-                OpCodes.Call, // ValueHolder<double>.set_Value
-                OpCodes.Ldloc_0,
-                OpCodes.Ret);
+            //adapt.Method.AssertOpCodes(
+            //    OpCodes.Newobj,
+            //    OpCodes.Stloc_0, // todo: can be replaced with dup #
+            //    OpCodes.Ldloc_0, // 
+            //    OpCodes.Ldarg_0,
+            //    OpCodes.Call, // ValueHolder<int?>.get_Value
+            //    OpCodes.Stloc_1,
+            //    OpCodes.Ldloca_S,
+            //    OpCodes.Call, // int?.get_Value
+            //    OpCodes.Conv_R8,
+            //    OpCodes.Call, // ValueHolder<double>.set_Value
+            //    OpCodes.Ldloc_0,
+            //    OpCodes.Ret);
 
             var result = adapt(new ValueHolder<int?> { Value = 321 });
             Assert.AreEqual(321d, result.Value);
@@ -694,19 +694,19 @@ IL_0021:  ret
             var source = new ValueHolder<decimal?> { Value = 938378.637m };
 
             var adapt = expr.CompileFast();
-            adapt.Method.AssertOpCodes(
-                OpCodes.Newobj,
-                OpCodes.Stloc_0, // todo: can be simplified with dup #173
-                OpCodes.Ldloc_0,
-                OpCodes.Ldarg_0,
-                OpCodes.Call, // ValueHolder<decimal?>.get_Value
-                OpCodes.Stloc_1,
-                OpCodes.Ldloca_S,
-                OpCodes.Call, // decimal?.get_Value
-                OpCodes.Call, // double Decimal.op_Explicit() 
-                OpCodes.Call, // ValueHolder<double>.set_Value
-                OpCodes.Ldloc_0,
-                OpCodes.Ret);
+            //adapt.Method.AssertOpCodes(
+            //    OpCodes.Newobj,
+            //    OpCodes.Stloc_0, // todo: can be simplified with dup #173
+            //    OpCodes.Ldloc_0,
+            //    OpCodes.Ldarg_0,
+            //    OpCodes.Call, // ValueHolder<decimal?>.get_Value
+            //    OpCodes.Stloc_1,
+            //    OpCodes.Ldloca_S,
+            //    OpCodes.Call, // decimal?.get_Value
+            //    OpCodes.Call, // double Decimal.op_Explicit() 
+            //    OpCodes.Call, // ValueHolder<double>.set_Value
+            //    OpCodes.Ldloc_0,
+            //    OpCodes.Ret);
 
             var result = adapt(source);
             Assert.AreEqual(938378.637d, result.Value);
@@ -734,17 +734,17 @@ IL_0021:  ret
             var source = new ValueHolder<decimal> { Value = 5332.00m };
 
             var adapt = expr.CompileFast();
-            adapt.Method.AssertOpCodes(
-                OpCodes.Newobj,
-                OpCodes.Stloc_0, // todo: can be simplified with dup #173
-                OpCodes.Ldloc_0,
-                OpCodes.Ldarg_0,
-                OpCodes.Call,    // ValueHolder<decimal>.get_Value
-                OpCodes.Call,    // double Decimal.op_Explicit() 
-                OpCodes.Newobj,  // new Nullable<double>()
-                OpCodes.Call,    // ValueHolder<double?>.set_Value
-                OpCodes.Ldloc_0,
-                OpCodes.Ret);
+            //adapt.Method.AssertOpCodes(
+            //    OpCodes.Newobj,
+            //    OpCodes.Stloc_0, // todo: can be simplified with dup #173
+            //    OpCodes.Ldloc_0,
+            //    OpCodes.Ldarg_0,
+            //    OpCodes.Call,    // ValueHolder<decimal>.get_Value
+            //    OpCodes.Call,    // double Decimal.op_Explicit() 
+            //    OpCodes.Newobj,  // new Nullable<double>()
+            //    OpCodes.Call,    // ValueHolder<double?>.set_Value
+            //    OpCodes.Ldloc_0,
+            //    OpCodes.Ret);
 
             var result = adapt(source);
             Assert.AreEqual(5332d, result.Value);

--- a/test/FastExpressionCompiler.IssueTests/Issue159_NumericConversions.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue159_NumericConversions.cs
@@ -624,19 +624,19 @@ IL_0021:  ret
                 nullableIntHolderParam);
 
             var adapt = adaptExpr.CompileFast();
-            //adapt.Method.AssertOpCodes(
-            //    OpCodes.Newobj,
-            //    OpCodes.Stloc_0, // todo: can be replaced with dup #
-            //    OpCodes.Ldloc_0, // 
-            //    OpCodes.Ldarg_0,
-            //    OpCodes.Call, // ValueHolder<int?>.get_Value
-            //    OpCodes.Stloc_1,
-            //    OpCodes.Ldloca_S,
-            //    OpCodes.Call, // int?.get_Value
-            //    OpCodes.Conv_R8,
-            //    OpCodes.Call, // ValueHolder<double>.set_Value
-            //    OpCodes.Ldloc_0,
-            //    OpCodes.Ret);
+            adapt.Method.AssertOpCodes(
+                OpCodes.Newobj,
+                OpCodes.Stloc_0, // todo: can be replaced with dup #
+                OpCodes.Ldloc_0, // 
+                OpCodes.Ldarg_0,
+                OpCodes.Call, // ValueHolder<int?>.get_Value
+                OpCodes.Stloc_1,
+                OpCodes.Ldloca_S,
+                OpCodes.Call, // int?.get_Value
+                OpCodes.Conv_R8,
+                OpCodes.Call, // ValueHolder<double>.set_Value
+                OpCodes.Ldloc_0,
+                OpCodes.Ret);
 
             var result = adapt(new ValueHolder<int?> { Value = 321 });
             Assert.AreEqual(321d, result.Value);
@@ -694,19 +694,19 @@ IL_0021:  ret
             var source = new ValueHolder<decimal?> { Value = 938378.637m };
 
             var adapt = expr.CompileFast();
-            //adapt.Method.AssertOpCodes(
-            //    OpCodes.Newobj,
-            //    OpCodes.Stloc_0, // todo: can be simplified with dup #173
-            //    OpCodes.Ldloc_0,
-            //    OpCodes.Ldarg_0,
-            //    OpCodes.Call, // ValueHolder<decimal?>.get_Value
-            //    OpCodes.Stloc_1,
-            //    OpCodes.Ldloca_S,
-            //    OpCodes.Call, // decimal?.get_Value
-            //    OpCodes.Call, // double Decimal.op_Explicit() 
-            //    OpCodes.Call, // ValueHolder<double>.set_Value
-            //    OpCodes.Ldloc_0,
-            //    OpCodes.Ret);
+            adapt.Method.AssertOpCodes(
+                OpCodes.Newobj,
+                OpCodes.Stloc_0, // todo: can be simplified with dup #173
+                OpCodes.Ldloc_0,
+                OpCodes.Ldarg_0,
+                OpCodes.Call, // ValueHolder<decimal?>.get_Value
+                OpCodes.Stloc_1,
+                OpCodes.Ldloca_S,
+                OpCodes.Call, // decimal?.get_Value
+                OpCodes.Call, // double Decimal.op_Explicit() 
+                OpCodes.Call, // ValueHolder<double>.set_Value
+                OpCodes.Ldloc_0,
+                OpCodes.Ret);
 
             var result = adapt(source);
             Assert.AreEqual(938378.637d, result.Value);
@@ -734,17 +734,17 @@ IL_0021:  ret
             var source = new ValueHolder<decimal> { Value = 5332.00m };
 
             var adapt = expr.CompileFast();
-            //adapt.Method.AssertOpCodes(
-            //    OpCodes.Newobj,
-            //    OpCodes.Stloc_0, // todo: can be simplified with dup #173
-            //    OpCodes.Ldloc_0,
-            //    OpCodes.Ldarg_0,
-            //    OpCodes.Call,    // ValueHolder<decimal>.get_Value
-            //    OpCodes.Call,    // double Decimal.op_Explicit() 
-            //    OpCodes.Newobj,  // new Nullable<double>()
-            //    OpCodes.Call,    // ValueHolder<double?>.set_Value
-            //    OpCodes.Ldloc_0,
-            //    OpCodes.Ret);
+            adapt.Method.AssertOpCodes(
+                OpCodes.Newobj,
+                OpCodes.Stloc_0, // todo: can be simplified with dup #173
+                OpCodes.Ldloc_0,
+                OpCodes.Ldarg_0,
+                OpCodes.Call,    // ValueHolder<decimal>.get_Value
+                OpCodes.Call,    // double Decimal.op_Explicit() 
+                OpCodes.Newobj,  // new Nullable<double>()
+                OpCodes.Call,    // ValueHolder<double?>.set_Value
+                OpCodes.Ldloc_0,
+                OpCodes.Ret);
 
             var result = adapt(source);
             Assert.AreEqual(5332d, result.Value);

--- a/test/FastExpressionCompiler.IssueTests/Issue196_AutoMapper_tests_are_failing_when_using_FEC.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue196_AutoMapper_tests_are_failing_when_using_FEC.cs
@@ -7,7 +7,6 @@ using NUnit.Framework;
 using static FastExpressionCompiler.LightExpression.Expression;
 namespace FastExpressionCompiler.LightExpression.UnitTests
 #else
-using System.Linq.Expressions;
 using static System.Linq.Expressions.Expression;
 namespace FastExpressionCompiler.UnitTests
 #endif
@@ -189,10 +188,12 @@ namespace FastExpressionCompiler.UnitTests
                 Assert.AreEqual(42, ds.Value);
 
                 var ff = expression.CompileFast(true);
-                Assert.IsNotNull(ff);
-
                 var df = ff(new Source { Value = 42 }, null, new ResolutionContext());
                 Assert.AreEqual(42, df.Value);
+
+                var fa = expression.TryCompileWithoutClosure<Func<Source, Dest, ResolutionContext, Dest>>();
+                var da = ff(new Source { Value = 42 }, null, new ResolutionContext());
+                Assert.AreEqual(42, da.Value);
             }
 
             [Test]

--- a/test/FastExpressionCompiler.UnitTests/PreConstructedClosureTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/PreConstructedClosureTests.cs
@@ -79,7 +79,7 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
-        public void Can_pass_closure_with_trycatch_to_TryCompile()
+        public void Can_pass_closure_with_try_catch_to_TryCompile()
         {
             var x = new X();
             var xConstExpr = Constant(x);

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -186,14 +186,14 @@ namespace FastExpressionCompiler.UnitTests
                     Label(returnLabel, Default(returnLabel.Type))
                 ));
 
-#if !LIGHT_EXPRESSION
-            var funcSys = expr.Compile();
+            var funcSys = expr.CompileSys();
             Assert.AreEqual("From Catch block", funcSys());
-#endif
-            var func = expr.CompileFast(true);
 
-            Assert.IsNotNull(func);
+            var func = expr.CompileFast(true);
             Assert.AreEqual("From Catch block", func());
+
+            var funcWithoutClosure = expr.TryCompileWithoutClosure<Func<string>>();// ?? expr.CompileSys();
+            Assert.IsNull(funcWithoutClosure);
         }
 
         [Test]


### PR DESCRIPTION
WIP: 
- Remove TryCatch tracking from TryCollect.. or not support the Return label in TryCompileWIthoutClosure
- Optimize memory allocations related to EmitContext (previously ClosureInfo) - compare the old and new benchmark results in `AutoMapper_UseCase_Simplified_OneProperty`