### PR TITLE
Remove castclass it should be unnecessary

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1830,7 +1830,7 @@ namespace FastExpressionCompiler
                 // source type is object, NonPassedParams is object array
                 if (paramType.IsValueType())
                 {
-                    il.Emit(OpCodes.Unbox_Any);
+                    il.Emit(OpCodes.Unbox_Any, paramType);
                 }
                 return true;
             }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1579,11 +1579,7 @@ namespace FastExpressionCompiler
 
                 if (expr.Arguments.Count == 1) // one dimensional array
                 {
-                    if (elemType.IsValueType())
-                        il.Emit(OpCodes.Ldelem, elemType);
-                    else
-                        il.Emit(OpCodes.Ldelem_Ref);
-                    return true;
+                    return TryEmitArrayIndex(elemType, il);
                 }
 
                 // multi dimensional array
@@ -1830,7 +1826,12 @@ namespace FastExpressionCompiler
                 il.Emit(OpCodes.Ldfld, ArrayClosureWithNonPassedParams.NonPassedParamsField);
                 EmitLoadConstantInt(il, nonPassedParamIndex);
                 il.Emit(OpCodes.Ldelem_Ref);
-                il.Emit(paramType.IsValueType() ? OpCodes.Unbox_Any : OpCodes.Castclass, paramType);
+
+                // source type is object, NonPassedParams is object array
+                if (paramType.IsValueType())
+                {
+                    il.Emit(OpCodes.Unbox_Any);
+                }
                 return true;
             }
 
@@ -2177,7 +2178,12 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Ldfld, ArrayClosure.ConstantsAndNestedLambdasField);
                     EmitLoadConstantInt(il, constIndex);
                     il.Emit(OpCodes.Ldelem_Ref);
-                    il.Emit(exprType.IsValueType() ? OpCodes.Unbox_Any : OpCodes.Castclass, exprType);
+
+                    // source type is object, ConstantsAndNestedLambdas is object array
+                    if (exprType.IsValueType())
+                    {
+                        il.Emit(OpCodes.Unbox_Any, exprType);
+                    }
                 }
                 else
                 {


### PR DESCRIPTION
ldelem_ref documentation says: 
Loads the element with an object reference at index onto the top of the stack as type O.

