### PR TITLE
Optimized FastExpressionCompiler output

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1830,7 +1830,7 @@ namespace FastExpressionCompiler
                 // source type is object, NonPassedParams is object array
                 if (paramType.IsValueType())
                 {
-                    il.Emit(OpCodes.Unbox_Any);
+                    il.Emit(OpCodes.Unbox_Any, paramType);
                 }
                 return true;
             }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -384,7 +384,14 @@ namespace FastExpressionCompiler
 
             // All nested lambdas recursively nested in expression
             public NestedLambdaInfo[] NestedLambdas;
-#endregion
+
+            // This integer stores location of Constants.Items local variable in stack
+            public int ClosureItemsVariableLocation;
+
+            // This integer array stores location of individual constants in expression
+            // Array is coupled with Constants LiveCountArray so that first index will hold index to first constant in stack
+            public int[] ConstantsVariableLocation;
+            #endregion
 
             // Populates info directly with provided closure object and constants.
             public ClosureInfo(bool isUserProvided, ConstantExpression[] usedProvidedClosureConstantExpressions = null)
@@ -392,6 +399,8 @@ namespace FastExpressionCompiler
                 NonPassedParameters = Tools.Empty<ParameterExpression>();
                 NestedLambdas = Tools.Empty<NestedLambdaInfo>();
 
+                ClosureItemsVariableLocation = -1;
+                ConstantsVariableLocation = null;
                 LastEmitIsAddress = false;
                 CurrentTryCatchFinallyIndex = -1;
                 _tryCatchFinallyInfos = null;
@@ -2166,18 +2175,56 @@ namespace FastExpressionCompiler
                 if (expr != null && IsClosureBoundConstant(constantValue, constantType.GetTypeInfo()))
                 {
                     var closureConstants = closure.Constants;
+                    var constantCount = closureConstants.Count;
+                    var constIndex = constantCount - 1;
 
-                    var constIndex = closureConstants.Count - 1;
                     while (constIndex >= 0 && !ReferenceEquals(closureConstants.Items[constIndex], expr))
                         --constIndex;
                     if (constIndex == -1)
                         return false;
 
-                    // Load constant from Closure - closure object is always a first argument
-                    il.Emit(OpCodes.Ldarg_0);
-                    il.Emit(OpCodes.Ldfld, ArrayClosure.ConstantsAndNestedLambdasField);
-                    EmitLoadConstantInt(il, constIndex);
-                    il.Emit(OpCodes.Ldelem_Ref);
+                    // If expression is small and there is no variables set then just read them by args and field
+                    if (constantCount <= 3 && closure.ClosureItemsVariableLocation == -1)
+                    {
+                        // Load constant from Closure - closure object is always a first argument
+                        il.Emit(OpCodes.Ldarg_0);
+                        il.Emit(OpCodes.Ldfld, ArrayClosure.ConstantsAndNestedLambdasField);
+                        EmitLoadConstantInt(il, constIndex);
+                        il.Emit(OpCodes.Ldelem_Ref);
+
+                        return true;
+                    }
+
+                    // When expressions are large its better to store constants into variables so they can be re-used later
+                    if (closure.ClosureItemsVariableLocation == -1)
+                    {
+                        // Load constant from Closure - closure object is always a first argument
+                        il.Emit(OpCodes.Ldarg_0);
+                        il.Emit(OpCodes.Ldfld, ArrayClosure.ConstantsAndNestedLambdasField); // Load Items field
+                        var closureItemsVarBuilder = il.DeclareLocal(typeof(object[]));
+                        var closureItemsVariableLocation = closureItemsVarBuilder.LocalIndex;
+
+                        closure.ClosureItemsVariableLocation = closureItemsVariableLocation;
+                        EmitStoreLocalVariable(il, closureItemsVariableLocation); // Store items array to variable
+
+                        // Store to variable
+                        closure.ConstantsVariableLocation = new int[constantCount];
+
+                        for (var i = 0; i < constantCount; i++)
+                        {
+                            var variableBuilder = il.DeclareLocal(closureConstants.Items[i].Type);
+                            var constantVariableLocation = variableBuilder.LocalIndex;
+                            // Store variable location for easy access later
+                            closure.ConstantsVariableLocation[i] = constantVariableLocation;
+
+                            EmitLoadLocalVariable(il, closureItemsVariableLocation);
+                            EmitLoadConstantInt(il, closureItemsVariableLocation);
+                            il.Emit(OpCodes.Ldelem_Ref);
+                            EmitStoreLocalVariable(il, constantVariableLocation);
+                        }
+                    }
+
+                    EmitLoadLocalVariable(il, closure.ConstantsVariableLocation[constIndex]);
 
                     // source type is object, ConstantsAndNestedLambdas is object array
                     if (exprType.IsValueType())
@@ -3772,6 +3819,56 @@ namespace FastExpressionCompiler
                         break;
                     default:
                         il.Emit(OpCodes.Ldc_I4, i);
+                        break;
+                }
+            }
+
+            private static void EmitLoadLocalVariable(ILGenerator il, int location)
+            {
+                switch (location)
+                {
+                    case 0:
+                        il.Emit(OpCodes.Ldloc_0);
+                        break;
+                    case 1:
+                        il.Emit(OpCodes.Ldloc_1);
+                        break;
+                    case 2:
+                        il.Emit(OpCodes.Ldloc_2);
+                        break;
+                    case 3:
+                        il.Emit(OpCodes.Ldloc_3);
+                        break;
+                    case int n when n > -129 && n < 128:
+                        il.Emit(OpCodes.Ldloc_S, (sbyte)location);
+                        break;
+                    default:
+                        il.Emit(OpCodes.Ldloc, (short)location);
+                        break;
+                }
+            }
+
+            private static void EmitStoreLocalVariable(ILGenerator il, int location)
+            {
+                switch (location)
+                {
+                    case 0:
+                        il.Emit(OpCodes.Stloc_0);
+                        break;
+                    case 1:
+                        il.Emit(OpCodes.Stloc_1);
+                        break;
+                    case 2:
+                        il.Emit(OpCodes.Stloc_2);
+                        break;
+                    case 3:
+                        il.Emit(OpCodes.Stloc_3);
+                        break;
+                    case int n when n > -129 && n < 128:
+                        il.Emit(OpCodes.Stloc_S, (sbyte)location);
+                        break;
+                    default:
+                        il.Emit(OpCodes.Stloc, (short)location);
                         break;
                 }
             }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1579,11 +1579,7 @@ namespace FastExpressionCompiler
 
                 if (expr.Arguments.Count == 1) // one dimensional array
                 {
-                    if (elemType.IsValueType())
-                        il.Emit(OpCodes.Ldelem, elemType);
-                    else
-                        il.Emit(OpCodes.Ldelem_Ref);
-                    return true;
+                    return TryEmitArrayIndex(elemType, il);
                 }
 
                 // multi dimensional array
@@ -1830,7 +1826,12 @@ namespace FastExpressionCompiler
                 il.Emit(OpCodes.Ldfld, ArrayClosureWithNonPassedParams.NonPassedParamsField);
                 EmitLoadConstantInt(il, nonPassedParamIndex);
                 il.Emit(OpCodes.Ldelem_Ref);
-                il.Emit(paramType.IsValueType() ? OpCodes.Unbox_Any : OpCodes.Castclass, paramType);
+
+                // source type is object, NonPassedParams is object array
+                if (paramType.IsValueType())
+                {
+                    il.Emit(OpCodes.Unbox_Any);
+                }
                 return true;
             }
 
@@ -2177,7 +2178,12 @@ namespace FastExpressionCompiler
                     il.Emit(OpCodes.Ldfld, ArrayClosure.ConstantsAndNestedLambdasField);
                     EmitLoadConstantInt(il, constIndex);
                     il.Emit(OpCodes.Ldelem_Ref);
-                    il.Emit(exprType.IsValueType() ? OpCodes.Unbox_Any : OpCodes.Castclass, exprType);
+
+                    // source type is object, ConstantsAndNestedLambdas is object array
+                    if (exprType.IsValueType())
+                    {
+                        il.Emit(OpCodes.Unbox_Any, exprType);
+                    }
                 }
                 else
                 {

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -391,7 +391,7 @@ namespace FastExpressionCompiler
             // This integer array stores location of individual constants in expression
             // Array is coupled with Constants LiveCountArray so that first index will hold index to first constant in stack
             public int[] ConstantsVariableLocation;
-            #endregion
+#endregion
 
             // Populates info directly with provided closure object and constants.
             public ClosureInfo(bool isUserProvided, ConstantExpression[] usedProvidedClosureConstantExpressions = null)
@@ -3873,7 +3873,7 @@ namespace FastExpressionCompiler
 
             private static void EmitConstantsAndNestedLambdasFieldToStack(ILGenerator il, ClosureInfo closure)
             {
-                // When there are no variables declared read first argument field
+                // When there are no variables declared read first argument and field
                 if (closure.ClosureItemsVariableLocation == -1)
                 {
                     // Load constant from Closure - closure object is always a first argument


### PR DESCRIPTION
This changeset also includes PATCH-1 ( https://github.com/dadhi/FastExpressionCompiler/pull/220 ) 

Continuation from here: 
https://github.com/dadhi/DryIoc/pull/162

In short:
This pull request optimizes large expressions by delcaring local variables for each constant. This way we can reduce repeating operations.

Based on the comments on previous PR I have tested that local variables work following way:
Change local variable threshold to 0 and run all tests - check. 
Change local variable threshold to 10000 and run all tests - check.

Those tests actually revealed some bugs in the code and they are fixed now.

I don't know how I can benchmark the compilation performance, but to minimize the impact I converted localbuilder array to integer and integer array.
