### PR TITLE
Various (minor) tweaks in regards to allocations and performance

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -119,11 +119,15 @@ namespace FastExpressionCompiler.LightExpression
             if (arguments.Count == 0)
                 return $"new {typeof(T).Name}[0]";
 
-            var s = "";
+            var s = new StringBuilder();
             for (var i = 0; i < arguments.Count; i++)
-                s += (i > 0 ? "," + NewLine : "") + arguments[i].CodeString;
+            {
+                if (i > 0)
+                    s.Append(",");
+                s.Append(arguments[i].CodeString);
+            }
 
-            return s;
+            return s.ToString();
         }
 
         public static ParameterExpression Parameter(Type type, string name = null) =>
@@ -459,11 +463,11 @@ namespace FastExpressionCompiler.LightExpression
             typeof(Action<,,,,>), typeof(Action<,,,,,>), typeof(Action<,,,,,,>)
         };
 
-        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters, Type returnType) =>
+        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, ParameterExpression[] parameters, Type returnType) where TDelegate : class =>
             new Expression<TDelegate>(body, parameters, returnType);
 
         /// todo: <paramref name="name"/> is ignored for now, the method is just for compatibility with SysExpression
-        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, string name, params ParameterExpression[] parameters) =>
+        public static Expression<TDelegate> Lambda<TDelegate>(Expression body, string name, params ParameterExpression[] parameters) where TDelegate : class =>
             new Expression<TDelegate>(body, parameters, GetDelegateReturnType(typeof(TDelegate)));
 
         /// <summary>Creates a BinaryExpression that represents applying an array index operator to an array of rank one.</summary>
@@ -775,13 +779,16 @@ namespace FastExpressionCompiler.LightExpression
             new SimpleBinaryExpression(ExpressionType.NotEqual, left, right, typeof(bool));
 
         public static BlockExpression Block(params Expression[] expressions) =>
+            Block(expressions[expressions.Length - 1].Type, Tools.Empty<ParameterExpression>(), expressions);
+
+        public static BlockExpression Block(IReadOnlyList<Expression> expressions) =>
             Block(Tools.Empty<ParameterExpression>(), expressions);
 
         public static BlockExpression Block(IEnumerable<ParameterExpression> variables, params Expression[] expressions) =>
-            Block(expressions[expressions.Length - 1].Type, variables.AsReadOnlyList(), expressions);
+            Block(variables.AsReadOnlyList(), new List<Expression>(expressions));
 
-        public static BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, params Expression[] expressions) =>
-            new BlockExpression(type, variables.AsReadOnlyList(), expressions);
+        public static BlockExpression Block(IReadOnlyList<ParameterExpression> variables, IReadOnlyList<Expression> expressions) =>
+            Block(expressions[expressions.Count - 1].Type, variables, expressions);
 
         public static BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) =>
             new BlockExpression(type, variables.AsReadOnlyList(), expressions.AsReadOnlyList());

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -792,6 +792,8 @@ namespace FastExpressionCompiler.LightExpression
 
         public static BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, IEnumerable<Expression> expressions) =>
             new BlockExpression(type, variables.AsReadOnlyList(), expressions.AsReadOnlyList());
+        public static BlockExpression Block(Type type, IEnumerable<ParameterExpression> variables, params Expression[] expressions) =>
+            new BlockExpression(type, variables.AsReadOnlyList(), expressions.AsReadOnlyList());
 
         /// <summary>
         /// Creates a LoopExpression with the given body and (optional) break target.

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -4302,7 +4302,7 @@ namespace FastExpressionCompiler
         {
             if (xs is T[] array)
                 return array;
-            return xs == null ? null : new List<T>(xs).ToArray();
+            return xs == null ? null : xs.ToArray();
         }
 
         private static class EmptyArray<T>
@@ -4377,16 +4377,29 @@ namespace FastExpressionCompiler
                 case 7: return typeof(Func<,,,,,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], paramTypes[3], paramTypes[4], paramTypes[5], paramTypes[6], returnType);
                 default:
                     throw new NotSupportedException(
-                        string.Format("Func with so many ({0}) parameters is not supported!", paramTypes.Length));
+                        $"Func with so many ({paramTypes.Length}) parameters is not supported!");
             }
         }
 
         public static T GetFirst<T>(this IEnumerable<T> source)
         {
+            // This is pretty much Linq.FirstOrDefault except it does not need to check
+            // if source is IPartition<T> (but should it?)
+
             if (source is IList<T> list)
                 return list.Count == 0 ? default : list[0];
             using (var items = source.GetEnumerator())
                 return items.MoveNext() ? items.Current : default;
+        }
+
+        public static T GetFirst<T>(this IList<T> source)
+        {
+            return source.Count == 0 ? default : source[0];
+        }
+
+        public static T GetFirst<T>(this T[] source)
+        {
+            return source.Length == 0 ? default : source[0];
         }
     }
 


### PR DESCRIPTION
First off, thank you for the work put into this.

I wanted to drop this library into my code to try it out (i write a performance-pressured code generator) but unfortunately it appears loops are not supported as part of 2.0 (I saw the PR for it, though, so that's nice). Anyways.

I noticed a few minor issues while looking through the code.
* `Expression.ToParamsCode<T>` uses string concatenation instead of a `StringBuilder`. This is probably not very important, but it's nicer now.
* `Expression.Block` is missing an overload accepting a `List<Expression>` for its body. Not a huge deal, but annoying, since `T[] ToArray()` generally implies an array copy (And this also contrasts with other static methods - note I did *not* check the overloads for `Linq.Expression`)
* `Tools.AsArray<T>(this IEnumerable<T> source)` uses a temporary list to load the enumerable and then turn it into a `T[]` (if source is not `T[]`). This is not pretty. because again, there is an implicit copy during `ToArray()`, on top of `List<T>` performing any possible number of resizes and copies when loading elements from the `IEnumerable<T>` it is provided.
This is the only one I actually wrote a benchmark for.

```
BenchmarkDotNet=v0.11.5, OS=Windows 10.0.18362
Intel Core i7-7700HQ CPU 2.80GHz (Kaby Lake), 1 CPU, 8 logical and 4 physical cores
.NET Core SDK=2.2.401
  [Host]     : .NET Core 2.2.6 (CoreCLR 4.6.27817.03, CoreFX 4.6.27818.02), 64bit RyuJIT
  DefaultJob : .NET Core 2.2.6 (CoreCLR 4.6.27817.03, CoreFX 4.6.27818.02), 64bit RyuJIT


|            Method | rangeMax |         Mean |         Error |        StdDev |    Gen 0 |    Gen 1 |    Gen 2 | Allocated |
|------------------ |--------- |-------------:|--------------:|--------------:|---------:|---------:|---------:|----------:|
| EnumerableToArray |      100 |     101.7 ns |      2.072 ns |      1.938 ns |   0.1347 |        - |        - |     424 B |
| EnumerableAsArray |      100 |     967.0 ns |     18.913 ns |     21.022 ns |   0.5245 |        - |        - |    1656 B |
| EnumerableToArray |     1000 |     889.0 ns |      4.192 ns |      3.921 ns |   1.2779 |        - |        - |    4024 B |
| EnumerableAsArray |     1000 |   7,154.9 ns |     21.956 ns |     18.334 ns |   3.9673 |        - |        - |   12496 B |
| EnumerableToArray |    10000 |   7,400.4 ns |    142.944 ns |    170.164 ns |  12.6495 |        - |        - |   40024 B |
| EnumerableAsArray |    10000 |  71,768.9 ns |    903.127 ns |    844.785 ns |  53.9551 |        - |        - |  171472 B |
| EnumerableToArray |   100000 |  75,608.7 ns |  1,241.826 ns |  1,100.846 ns | 124.8779 | 124.8779 | 124.8779 |  400024 B |
| EnumerableAsArray |   100000 | 810,969.4 ns | 13,054.779 ns | 11,572.722 ns | 399.4141 | 399.4141 | 399.4141 | 1449048 B |
```

And the benchmark itself: https://gist.github.com/Warpten/982949dfc362cff78b35c1b2c9668298

Now, I'm not sure whether or not there is an actual reason for this specific implementation, but cutting the temporary makes the code noticeably faster (although it is by no means a hot path for regular usage), and less allocatey: we get exactly what is expected from `ToArray<T>()` : 24 bytes for the overhead of `T[]`, and 4 bytes per element.

* And finally, I added some overloads to `GetFirst<T>`, to cut boxing. I also assume `GetFirst<T>()` is used in place of LINQ's `FirstOrDefault()` to avoid the `IPartition<T>` check. For now, this only affects one call site: `CodePrinter.ToCode`.

Now, I'm not sure what the best way to contribute; these are not huge issues, so I'm not sure splitting them into different pull requests would be welcomed. Additionally, should I add benchmarks for any of these? Please let me know.