### PR TITLE
WIP: Fix for #243

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue243_Pass_Parameter_By_Ref_is_supported.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue243_Pass_Parameter_By_Ref_is_supported.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using NUnit.Framework;
+
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests
+#endif
+{
+    [TestFixture]
+    public class Issue243_Pass_Parameter_By_Ref_is_supported
+    {
+        public static string PassByRef(ref string test)
+        {
+            return test.ToString();
+        }
+
+        public static string PassByValue(string test)
+        {
+            return test.ToString();
+        }
+
+        [Test]
+        public void Lambda_Parameter_Passed_Into_Ref_Method()
+        {
+            var parameter = Parameter(typeof(string));
+            var call = Call(GetType().GetMethod(nameof(PassByRef)), parameter);
+
+            var lambda = Lambda<Func<string, string>>(call, parameter);
+
+            var fastCompiled = lambda.CompileFast();
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual("test", fastCompiled("test"));
+        }
+
+        public delegate string RefDelegate(ref string val);
+
+        [Test]
+        public void Lambda_Ref_Parameter_Passed_Into_Ref_Method()
+        {
+            var parameter = Parameter(typeof(string).MakeByRefType());
+            var call = Call(GetType().GetMethod(nameof(PassByRef)), parameter);
+
+            var lambda = Lambda<RefDelegate>(call, parameter);
+
+            var fastCompiled = lambda.CompileFast();
+
+            var data = "test";
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(data, fastCompiled(ref data));
+        }
+
+        [Test]
+        public void Lambda_Ref_Parameter_Passed_Into_Value_Method()
+        {
+            var parameter = Parameter(typeof(string).MakeByRefType());
+            var call = Call(GetType().GetMethod(nameof(PassByValue)), parameter);
+
+            var lambda = Lambda<RefDelegate>(call, parameter);
+
+            var fastCompiled = lambda.CompileFast();
+
+            var data = "test";
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual(data, fastCompiled(ref data));
+        }
+
+        [Test]
+        public void Lambda_Parameter_Passed_Into_Ref_Method_Extra_Assignment()
+        {
+            var parameter = Parameter(typeof(string));
+
+            var variable = Variable(typeof(string));
+
+            var variables = new[]
+            {
+                variable
+            };
+
+            var body = Block(
+                variables,
+                Assign(variable, parameter),
+                Call(GetType().GetMethod(nameof(PassByRef)), variable)
+            );
+
+            var lambda = Lambda<Func<string, string>>(body, parameter);
+
+            var fastCompiled = lambda.CompileFast();
+
+            Assert.NotNull(fastCompiled);
+            Assert.AreEqual("test", fastCompiled("test"));
+        }
+    }
+}


### PR DESCRIPTION
My initial attempt at fixing issues in https://github.com/dadhi/FastExpressionCompiler/issues/243.

While I've managed to fix initial issue when writing tests I figured out one other case that was not tested - using `ref` parameters to then call normal by value methods. This is still causing failures and to be honest - without investing a lot of time I can't really tell what is a correct fix. I've added a comment above a line that might cause it - basically it should emit extra indirect reference load but it doesn't due to a conditional that I don't understand.