### PR TITLE
Remove Castclass from complex constants on .NET Core

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2991,8 +2991,14 @@ namespace FastExpressionCompiler
                         il.Emit(OpCodes.Ldelem_Ref);
                         if (exprType.IsValueType)
                             il.Emit(OpCodes.Unbox_Any, exprType);
-                        else // todo: @perf it is probably required only for Full CLR starting from NET45, e.g. `Test_283_Case6_MappingSchemaTests_CultureInfo_VerificationException`
+                        else
+                        {
+                            // this is probably required only for Full CLR starting from NET45, e.g. `Test_283_Case6_MappingSchemaTests_CultureInfo_VerificationException`
+                            // .NET Core does not seem to care about verifiability and it's faster without the explicit cast
+#if NETFRAMEWORK
                             il.Emit(OpCodes.Castclass, exprType);
+#endif
+                        }
                     }
                 }
                 else


### PR DESCRIPTION
It seems that this was introduced to mitigate an issue on .NET Framework,
so I left it on this platform. However, it seems unnecessary on
.NET Core and seems to create slight performance trouble
for me.

The NETFRAMEWORK constnant should be automatically defined by C#,
so no need to define it in csproj
(https://docs.microsoft.com/en-us/dotnet/standard/frameworks#how-to-specify-a-target-framework)

I don't know if I can write a test for this change since it does not change any behavior (or... it's not supposed to :sweat_smile:)