### PR TITLE
Fix #310 - nullable conversion with ignored result

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue310_InvalidProgramException_ignored_nullable.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue310_InvalidProgramException_ignored_nullable.cs
@@ -1,0 +1,45 @@
+using NUnit.Framework;
+using System;
+using System.Linq.Expressions;
+#if LIGHT_EXPRESSION
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.IssueTests
+#else
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.IssueTests
+#endif
+{
+    [TestFixture]
+    public class Issue310_InvalidProgramException_ignored_nullable
+    {
+        public int Run()
+        {
+            Test1();
+            Test2();
+            return 2;
+        }
+
+        [Test]
+        public void Test1()
+        {
+            var p = Parameter(typeof(int), "tmp0");
+            var expr = 
+                Lambda<Action<int>>(Block(
+                Convert(p, typeof(int?)),
+                Default(typeof(void))), p);
+
+            var f = expr.CompileFast();
+            f(2);
+        }
+
+        [Test]
+        public void Test2()
+        {
+            var p = Parameter(typeof(int), "tmp0");
+            var expr = 
+                Lambda<Action<int>>(Convert(p, typeof(int?)), new[] { p });
+            var f = expr.CompileFast();
+            f(2);
+        }
+    }
+}

--- a/test/FastExpressionCompiler.TestsRunner.Net472/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner.Net472/Program.cs
@@ -201,6 +201,9 @@ namespace FastExpressionCompiler.UnitTests
                 Run(new Issue308_Wrong_delegate_type_returned_with_closure().Run);
                 Run(new FastExpressionCompiler.LightExpression.IssueTests.Issue308_Wrong_delegate_type_returned_with_closure().Run);
 
+                Run(new Issue310_InvalidProgramException_ignored_nullable().Run);
+                Run(new FastExpressionCompiler.LightExpression.IssueTests.Issue310_InvalidProgramException_ignored_nullable().Run);
+
                 Console.WriteLine($"============={Environment.NewLine}IssueTests are passing in {sw.ElapsedMilliseconds} ms.");
             });
 

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -226,6 +226,9 @@ namespace FastExpressionCompiler.UnitTests
                 Run(new Issue308_Wrong_delegate_type_returned_with_closure().Run);
                 Run(new FastExpressionCompiler.LightExpression.IssueTests.Issue308_Wrong_delegate_type_returned_with_closure().Run);
 
+                Run(new Issue310_InvalidProgramException_ignored_nullable().Run);
+                Run(new FastExpressionCompiler.LightExpression.IssueTests.Issue310_InvalidProgramException_ignored_nullable().Run);
+
                 Console.WriteLine($"============={Environment.NewLine}IssueTests are passing in {sw.ElapsedMilliseconds} ms.");
             });
 


### PR DESCRIPTION
It should also help a bit other conversions with ignored result -
whenever we know what the conversion will always pass, we
don't need to emit any code. In some cases, this may save a boxing
conversion (and it will probably save some work for the JIT)