### PR TITLE
ToCsharpCode: format block inside expression in `{ ... }`

### DIFF
--- a/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
+++ b/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
@@ -1,6 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net472;net7.0</TargetFrameworks>
+        <TargetFrameworks>net472;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
+++ b/test/FastExpressionCompiler.UnitTests/FastExpressionCompiler.UnitTests.csproj
@@ -1,7 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
         <TargetFrameworks>net472;net7.0</TargetFrameworks>
-        <TargetFrameworks>net472;net6.0</TargetFrameworks>
     </PropertyGroup>
 
     <ItemGroup>

--- a/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
@@ -31,6 +31,35 @@ namespace FastExpressionCompiler.UnitTests
             Assert.AreEqual(typeof(A<string>), f());
         }
 
+        [Test]
+        public void Outputs_default_reference_type_is_just_null()
+        {
+            var cs = Default(typeof(string)).ToCSharpString();
+            Assert.AreEqual("null;", cs);
+
+            cs = Default(typeof(System.Collections.Generic.List<string>)).ToCSharpString();
+            Assert.AreEqual("null;", cs);
+        }
+
+        [Test]
+        public void Somehow_handles_block_in_expression()
+        {
+            // it's probably not possible to output compilable C# for expressions like this, but at least it can be easy to read
+            var variable = Parameter(typeof(int), "variable");
+            var cs = Add(Constant(1), Block(new [] { variable },
+                Assign(variable, Constant(2)),
+                variable
+            )).ToCSharpString();
+            Assert.AreEqual("""
+                    (1 + {
+                        int variable;
+                        variable = 2;
+                        variable;
+                    });
+                    """, cs);
+        }
+
+
         class A<X> {}
     }
 }


### PR DESCRIPTION
When a block is inside another expression (binary, unary, assignment) it is now formatted into braces. It's not valid C# code, but neither was it valid before this change. This makes the code eaiser to read (IMHO), since the block scope is clearly visible.

My example expression, before the change:

```csharp
{
    ....
    return ((object)(Command)(() => //$
{
    vm_this.Title = ((string)((string)
        HierarchyControl tmp0;                       // <- variable randomly declared after the cast
        tmp0 = ((HierarchyControl)control1 != null ?
            control1.GetClosestControlBindingTarget() :
            default(DotvvmBindableObject));
        tmp0 != null ?
            tmp0.GetValue(
                ...,
                true) :
            default(object)));
    return 
        Task.CompletedTask;
}));
    object__5216800:;
});

```

After the change:

```csharp
(BindingDelegate)((DotvvmBindableObject currentControl) =>
{
    ...
    return ((object)(Command)(() =>
    {
        vm_this.Title = ((string){
                HierarchyControl tmp0;
                tmp0 = ((HierarchyControl)(control1 != null) ?
                    control1.GetClosestControlBindingTarget() :
                    null);
                (tmp0 != null) ?
                    tmp0.GetValue(
                        ...,
                        true) :
                    null;
            });
        return Task.CompletedTask;
    }));
    object__48756912:;
});
```

If you have any other ideas how to format such code, I'd be happy to incomporate them. I was considering these alternatives:

* Instead of `{ ... }`, rewrite it as `(Func<ResultType>() => { })()`, since that would compile.
   - However, it would break return/break/goto semantics, so it's "correct" solution either. 
   - It's more noisy and might be confusing - it creates a lambda function, while there was nothing like in the expression.
* Rewrite `unary(block(a, b, c, d))` -> `block(a, b, c, unary(d))`.
   - That would be nicer, but would only work for this specific case.
   - Adding it to all cases would be a lot of changes.
   - And, this approach can't handle more complex cases like `binary(Method1(), Block(Method2()))`, I'd either have to reorder the method calls (incorrect), or add temporary variables (complex and noisy)