### PR TITLE
LightExpression: support for up to 16 Action<> and Func<> params

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -5646,35 +5646,65 @@ namespace FastExpressionCompiler
         {
             if (returnType == typeof(void))
             {
-                switch (paramTypes.Length)
-                {
-                    case 0: return typeof(Action);
-                    case 1: return typeof(Action<>).MakeGenericType(paramTypes);
-                    case 2: return typeof(Action<,>).MakeGenericType(paramTypes);
-                    case 3: return typeof(Action<,,>).MakeGenericType(paramTypes);
-                    case 4: return typeof(Action<,,,>).MakeGenericType(paramTypes);
-                    case 5: return typeof(Action<,,,,>).MakeGenericType(paramTypes);
-                    case 6: return typeof(Action<,,,,,>).MakeGenericType(paramTypes);
-                    case 7: return typeof(Action<,,,,,,>).MakeGenericType(paramTypes);
-                    default:
-                        throw new NotSupportedException(
-                            $"Action with so many ({paramTypes.Length}) parameters is not supported!");
-                }
+                if (paramTypes.Length == 0)
+                    return typeof(Action);
+
+                return GetAction(paramTypes.Length).MakeGenericType(paramTypes);
             }
 
-            switch (paramTypes.Length)
+            Type funcType = GetFunc(paramTypes.Length);
+            Type[] typeParams = new Type[paramTypes.Length + 1];
+            Array.Copy(paramTypes, typeParams, paramTypes.Length);
+            typeParams[paramTypes.Length] = returnType;
+            return funcType.MakeGenericType(typeParams);
+
+            static Type GetAction(int length)
             {
-                case 0: return typeof(Func<>).MakeGenericType(returnType);
-                case 1: return typeof(Func<,>).MakeGenericType(paramTypes[0], returnType);
-                case 2: return typeof(Func<,,>).MakeGenericType(paramTypes[0], paramTypes[1], returnType);
-                case 3: return typeof(Func<,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], returnType);
-                case 4: return typeof(Func<,,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], paramTypes[3], returnType);
-                case 5: return typeof(Func<,,,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], paramTypes[3], paramTypes[4], returnType);
-                case 6: return typeof(Func<,,,,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], paramTypes[3], paramTypes[4], paramTypes[5], returnType);
-                case 7: return typeof(Func<,,,,,,,>).MakeGenericType(paramTypes[0], paramTypes[1], paramTypes[2], paramTypes[3], paramTypes[4], paramTypes[5], paramTypes[6], returnType);
-                default:
-                    throw new NotSupportedException(
-                        $"Func with so many ({paramTypes.Length}) parameters is not supported!");
+                return length switch
+                {
+                    1 => typeof(Action<>),
+                    2 => typeof(Action<,>),
+                    3 => typeof(Action<,,>),
+                    4 => typeof(Action<,,,>),
+                    5 => typeof(Action<,,,,>),
+                    6 => typeof(Action<,,,,,>),
+                    7 => typeof(Action<,,,,,,>),
+                    8 => typeof(Action<,,,,,,,>),
+                    9 => typeof(Action<,,,,,,,,>),
+                    10 => typeof(Action<,,,,,,,,,>),
+                    11 => typeof(Action<,,,,,,,,,,>),
+                    12 => typeof(Action<,,,,,,,,,,,>),
+                    13 => typeof(Action<,,,,,,,,,,,,>),
+                    14 => typeof(Action<,,,,,,,,,,,,,>),
+                    15 => typeof(Action<,,,,,,,,,,,,,,>),
+                    16 => typeof(Action<,,,,,,,,,,,,,,,>),
+                    _ => throw new NotSupportedException($"Action with so many ({length}) parameters is not supported!")
+                };
+            }
+
+            static Type GetFunc(int length)
+            {
+                return length switch
+                {
+                    0 => typeof(Func<>),
+                    1 => typeof(Func<,>),
+                    2 => typeof(Func<,,>),
+                    3 => typeof(Func<,,,>),
+                    4 => typeof(Func<,,,,>),
+                    5 => typeof(Func<,,,,,>),
+                    6 => typeof(Func<,,,,,,>),
+                    7 => typeof(Func<,,,,,,,>),
+                    8 => typeof(Func<,,,,,,,,>),
+                    9 => typeof(Func<,,,,,,,,,>),
+                    10 => typeof(Func<,,,,,,,,,,>),
+                    11 => typeof(Func<,,,,,,,,,,,>),
+                    12 => typeof(Func<,,,,,,,,,,,,>),
+                    13 => typeof(Func<,,,,,,,,,,,,,>),
+                    14 => typeof(Func<,,,,,,,,,,,,,,>),
+                    15 => typeof(Func<,,,,,,,,,,,,,,,>),
+                    16 => typeof(Func<,,,,,,,,,,,,,,,,>),
+                    _ => throw new NotSupportedException($"Func with so many ({length}) parameters is not supported!")
+                };  
             }
         }
 

--- a/test/FastExpressionCompiler.LightExpression.IssueTests/Issue363_ActionFunc16Generics.cs
+++ b/test/FastExpressionCompiler.LightExpression.IssueTests/Issue363_ActionFunc16Generics.cs
@@ -1,0 +1,101 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using NUnit.Framework;
+using static FastExpressionCompiler.LightExpression.Expression;
+
+namespace FastExpressionCompiler.LightExpression.IssueTests
+{
+    [TestFixture]
+    internal class Issue363_ActionFunc16Generics
+    {
+        public static readonly object[] TestCases = Enumerable.Range(0, 16).Cast<object>().ToArray();
+
+        [Test]
+        public void Supports_16_Func_Params()
+        {
+            LambdaExpression lambda = Lambda(
+                Constant(0L),
+                Enumerable.Range(0, 16)
+                .Select(i => Parameter(typeof(int), $"p{i}")));
+
+            var compiled = lambda.CompileFast<
+                Func<
+                int, int, int, int,
+                int, int, int, int,
+                int, int, int, int,
+                int, int, int, int,
+                long>>(flags: CompilerFlags.ThrowOnNotSupportedExpression);
+
+            Assert.NotNull(compiled);
+            Assert.AreEqual(0L, compiled(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15));
+        }
+
+        [Test]
+        public void Supports_16_Action_Params()
+        {
+            LambdaExpression lambda = Lambda(
+                Empty(),
+                Enumerable.Range(0, 16)
+                .Select(i => Parameter(typeof(int), $"p{i}")));
+
+            var compiled = lambda.CompileFast<
+                Action<
+                int, int, int, int,
+                int, int, int, int,
+                int, int, int, int,
+                int, int, int, int
+                >>(flags: CompilerFlags.ThrowOnNotSupportedExpression);
+
+            Assert.NotNull(compiled);
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void Can_Create_Func(int paramCount)
+        {
+            ParameterExpression[] parameters = Enumerable
+                .Range(0, paramCount)
+                .Select(i => Parameter(typeof(int), $"p{i}"))
+                .ToArray();
+
+            NewArrayExpression arrayInit = NewArrayInit(typeof(int), parameters);
+
+            LambdaExpression lambda = Lambda(arrayInit, parameters);
+
+            // (a, b, c, ...) => new[] { a, b, c, ... }
+            Delegate compiled = lambda.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
+
+            int[] result = (int[])compiled.DynamicInvoke(parameters.Select(_ => (object)1).ToArray());
+
+            Assert.AreEqual(paramCount, result.Length);
+        }
+
+        [TestCaseSource(nameof(TestCases))]
+        public void Can_Create_Action(int paramCount)
+        {
+            ParameterExpression[] parameters = Enumerable
+                .Range(0, paramCount)
+                .Select(i => Parameter(typeof(int), $"p{i}"))
+                .ToArray();
+
+            List<int> list = new();
+
+            MethodInfo addMethod = typeof(List<int>).GetMethod(nameof(List<int>.Add));
+            ConstantExpression listExp = Constant(list);
+            BlockExpression body = Block(
+                typeof(void),
+                parameters.Select((p) => (Expression)Call(listExp, addMethod, p)).ToArray());
+
+            LambdaExpression lambda = Lambda(body, parameters);
+
+            // (a, b, c, ...) => list.Add(a); list.Add(b); list.Add(c); ...
+            Delegate compiled = lambda.CompileFast(flags: CompilerFlags.ThrowOnNotSupportedExpression);
+
+            compiled.DynamicInvoke(parameters.Select(_ => (object)1).ToArray());
+
+            Assert.AreEqual(paramCount, list.Sum());
+        }
+
+    }
+}


### PR DESCRIPTION
fixes #363

Hopefully the tests are acceptable, tested every param count with DynamicInvoke, and 16 param versions with generics to ensure they compile.