### PR TITLE
Remove ClosureInfo from the NestedLambdaInfo to minimize memory alloc on heap

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -64,9 +64,9 @@ namespace FastExpressionCompiler.LightExpression
         /// constant and the nested lambdas. Beside that the labels, block and try-catch information is also collected
         /// for the next IL-emitting stage. The information regarding the currently traversed lambda expression
         /// is accumulated in the `closure` structure. The `rootClosure` hold the first lambda expression info
-        /// for any nested lambda expression, which is indicated by `isNestedLambda`.</summary>
+        /// for any nested lambda expression, which is indicated by `nestedLambda`.</summary>
         public virtual bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) => false;
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) => false;
         /// <summary>The second FEC state to emit the actual IL op-codes based on the information collected by the first traversal
         /// and available in the `closure` structure. Find the expression examples below by searching `IsIntrinsic => true`.</summary>
         public virtual bool TryEmit(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
@@ -2320,8 +2320,8 @@ namespace FastExpressionCompiler.LightExpression
         public override bool IsIntrinsic => true;
 
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Operand, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Operand, paramExprs, nestedLambda, ref rootClosure, config);
 
         public override bool TryEmit(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
@@ -2847,7 +2847,7 @@ namespace FastExpressionCompiler.LightExpression
         internal NoArgsNewClassIntrinsicExpression(ConstructorInfo constructor) : base(constructor) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) => true;
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) => true;
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -2871,8 +2871,8 @@ namespace FastExpressionCompiler.LightExpression
         internal NoByRefOneArgNewIntrinsicExpression(ConstructorInfo constructor, object arg) : base(constructor, arg) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -2901,9 +2901,9 @@ namespace FastExpressionCompiler.LightExpression
         internal NoByRefTwoArgumentsNewIntrinsicExpression(ConstructorInfo constructor, object a0, object a1) : base(constructor, a0, a1) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -2938,10 +2938,10 @@ namespace FastExpressionCompiler.LightExpression
             : base(constructor, a0, a1, a2) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -2978,11 +2978,11 @@ namespace FastExpressionCompiler.LightExpression
             : base(constructor, a0, a1, a2, a3) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -3022,12 +3022,12 @@ namespace FastExpressionCompiler.LightExpression
             : base(constructor, a0, a1, a2, a3, a4) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -3070,13 +3070,13 @@ namespace FastExpressionCompiler.LightExpression
             : base(constructor, a0, a1, a2, a3, a4, a5) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument5, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument5, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -3121,14 +3121,14 @@ namespace FastExpressionCompiler.LightExpression
             : base(constructor, a0, a1, a2, a3, a4, a5, a6) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure) =>
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument5, paramExprs, isNestedLambda, ref rootClosure, config) &&
-            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument6, paramExprs, isNestedLambda, ref rootClosure, config);
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure) =>
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument0, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument1, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument2, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument3, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument4, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument5, paramExprs, nestedLambda, ref rootClosure, config) &&
+            ExpressionCompiler.TryCollectBoundConstants(ref closure, Argument6, paramExprs, nestedLambda, ref rootClosure, config);
         public override bool TryEmit(CompilerFlags setup, ref ClosureInfo closure, IParameterProvider paramExprs,
             ILGenerator il, ParentFlags parent, int byRefIndex = -1)
         {
@@ -3160,11 +3160,11 @@ namespace FastExpressionCompiler.LightExpression
         internal NoByRefManyArgsNewIntrinsicExpression(ConstructorInfo constructor, IReadOnlyList<Expression> arguments) : base(constructor, arguments) { }
         public override bool IsIntrinsic => true;
         public override bool TryCollectBoundConstants(CompilerFlags config, ref ClosureInfo closure, IParameterProvider paramExprs,
-            bool isNestedLambda, ref ClosureInfo rootClosure)
+            NestedLambdaInfo nestedLambda, ref ClosureInfo rootClosure)
         {
             var args = Args;
             for (var i = 0; i < args.Count; i++)
-                if (!ExpressionCompiler.TryCollectBoundConstants(ref closure, args[i], paramExprs, isNestedLambda, ref rootClosure, config))
+                if (!ExpressionCompiler.TryCollectBoundConstants(ref closure, args[i], paramExprs, nestedLambda, ref rootClosure, config))
                     return false;
             return true;
         }

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -2842,7 +2842,6 @@ namespace FastExpressionCompiler.LightExpression
         internal override SysExpr CreateSysExpression(ref LiveCountArray<LightAndSysExpr> exprsConverted) => SysExpr.New(Type);
     }
 
-
     public sealed class NoArgsNewClassIntrinsicExpression : NewExpression
     {
         internal NoArgsNewClassIntrinsicExpression(ConstructorInfo constructor) : base(constructor) { }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -497,23 +497,6 @@ namespace FastExpressionCompiler
                 return null;
 
             var nestedLambdaOrLambdas = closureInfo.NestedLambdaOrLambdas; // todo: @perf @mem can we pool a single nested lambda info?
-            // if (nestedLambdaOrLambdas != null)
-            // {
-            //     if (nestedLambdaOrLambdas is NestedLambdaInfo[] nestedLambdas)
-            //     {
-            //         foreach (var nestedLambda in nestedLambdas)
-            //         {
-            //             if (nestedLambda.Lambda == null && !TryCompileNestedLambda(nestedLambda, flags))
-            //                 return null;
-            //         }
-            //     }
-            //     else
-            //     {
-            //         var nestedLambda = (NestedLambdaInfo)nestedLambdaOrLambdas;
-            //         if (nestedLambda.Lambda == null && !TryCompileNestedLambda(nestedLambda, flags))
-            //             return null;
-            //     }
-            // }
 
             ArrayClosure closure;
             if ((flags & CompilerFlags.EnableDelegateDebugInfo) == 0)
@@ -1640,25 +1623,6 @@ namespace FastExpressionCompiler
 #endif
             ref var nestedClosureInfo = ref nestedLambdaInfo.ClosureInfo;
             var nestedLambdaNestedLambdaOrLambdas = nestedClosureInfo.NestedLambdaOrLambdas;
-            // if (nestedLambdaNestedLambdaOrLambdas != null)
-            // {
-            //     if (nestedLambdaNestedLambdaOrLambdas is NestedLambdaInfo[] nestedLambdaNestedLambdas)
-            //     {
-            //         foreach (var nestedLambdaInNestedLambda in nestedLambdaNestedLambdas)
-            //         {
-            //             if (nestedLambdaInNestedLambda.Lambda == null &&
-            //                 !TryCompileNestedLambda(nestedLambdaInNestedLambda, setup))
-            //                 return false;
-            //         }
-            //     }
-            //     else
-            //     {
-            //         var nestedLambdaInNestedLambda = (NestedLambdaInfo)nestedLambdaNestedLambdaOrLambdas;
-            //         if (nestedLambdaInNestedLambda.Lambda == null &&
-            //             !TryCompileNestedLambda(nestedLambdaInNestedLambda, setup))
-            //             return false;
-            //     }
-            // }
 
             ArrayClosure nestedLambdaClosure = null;
             if (nestedClosureInfo.NonPassedParameters.Count == 0)

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1303,7 +1303,6 @@ namespace FastExpressionCompiler
                                 return error;
                         }
 
-                        // todo: @bug ? currently it propagates variables used by the nested lambda but defined in current lambda
                         ref var nestedNonPassedParams = ref nestedLambdaInfo.ClosureInfo.NonPassedParameters;
                         if (nestedNonPassedParams.Count != 0)
                             PropagateNonPassedParamsToOuterLambda(ref closure, paramExprs, nestedParamExprs, ref nestedNonPassedParams);

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -668,6 +668,7 @@ namespace FastExpressionCompiler
                 CurrentInlinedLambdaInvokeIndex = -1;
             }
 
+            [MethodImpl((MethodImplOptions)256)]
             public bool ContainsConstantsOrNestedLambdas() => Constants.Count > 0 || NestedLambdaOrLambdas != null;
 
             public bool AddConstantOrIncrementUsageCount(object value)
@@ -1288,7 +1289,7 @@ namespace FastExpressionCompiler
 
                         if (nestedLambdaInfo.Lambda != null)
                             return 0;
-                        if (!TryCompileNestedLambda(nestedLambdaInfo, flags))
+                        if (!TryCompileNestedLambda(ref nestedLambdaInfo.ClosureInfo, nestedLambdaInfo, flags))
                             return 102;
 
                         return 0; // SUCCESS // todo: @wip to constant
@@ -1599,7 +1600,7 @@ namespace FastExpressionCompiler
             return false;
         }
 
-        private static bool TryCompileNestedLambda(NestedLambdaInfo nestedLambdaInfo, CompilerFlags setup)
+        private static bool TryCompileNestedLambda(ref ClosureInfo nestedClosureInfo, NestedLambdaInfo nestedLambdaInfo, CompilerFlags setup)
         {
             // 1. Try to compile nested lambda in place
             // 2. Check that parameters used in compiled lambda are passed or closed by outer lambda
@@ -1621,7 +1622,6 @@ namespace FastExpressionCompiler
 #else
             var nestedLambdaParamExprs = nestedLambdaExpr.Parameters;
 #endif
-            ref var nestedClosureInfo = ref nestedLambdaInfo.ClosureInfo;
             var nestedLambdaNestedLambdaOrLambdas = nestedClosureInfo.NestedLambdaOrLambdas;
 
             ArrayClosure nestedLambdaClosure = null;

--- a/test/FastExpressionCompiler.Benchmarks/ApexSerialization_SerializeDictionary.cs
+++ b/test/FastExpressionCompiler.Benchmarks/ApexSerialization_SerializeDictionary.cs
@@ -68,7 +68,6 @@ BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.1992/22H2/2022Update/SunValley2)
 | CompileFast |  21.66 us |  0.422 us |  0.330 us |  21.71 us |  1.00 |    0.00 | 1.1902 | 1.1597 |    7.3 KB |        1.00 |
 |  CompileSys | 506.46 us | 10.053 us | 28.024 us | 495.90 us | 22.69 |    0.93 | 3.9063 | 2.9297 |  27.41 KB |        3.76 |
 
-## 
 
 */
         [MemoryDiagnoser]

--- a/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
+++ b/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
@@ -103,6 +103,13 @@ BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.1992/22H2/2022Update/SunValley2)
 | LightExpression_with_sub_expressions_CompiledFast |  18.82 us |  0.373 us |  0.894 us |  18.53 us |  1.00 |    0.00 | 1.4648 | 1.3428 |   9.02 KB |        1.00 |
 |          Expression_with_sub_expressions_Compiled | 508.95 us | 10.150 us | 24.320 us | 498.55 us | 27.09 |    1.65 | 3.9063 | 2.9297 |  28.47 KB |        3.15 |
 
+### Removed ClosureInfo from the LambdaInfo
+
+|                                            Method |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|-------------------------------------------------- |----------:|----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
+| LightExpression_with_sub_expressions_CompiledFast |  20.96 us |  0.417 us |  1.098 us |  20.67 us |  1.00 |    0.00 | 1.2817 | 1.2512 |   7.99 KB |        1.00 |
+|          Expression_with_sub_expressions_Compiled | 584.61 us | 25.681 us | 71.163 us | 554.55 us | 28.18 |    4.04 | 3.9063 | 2.9297 |  28.47 KB |        3.56 |
+
 */
         private Expression<Func<A>> _expr;//, _exprWithVars;
         private LightExpression.Expression<Func<A>> _lightExpr;

--- a/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
+++ b/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
@@ -110,6 +110,13 @@ BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.1992/22H2/2022Update/SunValley2)
 | LightExpression_with_sub_expressions_CompiledFast |  20.96 us |  0.417 us |  1.098 us |  20.67 us |  1.00 |    0.00 | 1.2817 | 1.2512 |   7.99 KB |        1.00 |
 |          Expression_with_sub_expressions_Compiled | 584.61 us | 25.681 us | 71.163 us | 554.55 us | 28.18 |    4.04 | 3.9063 | 2.9297 |  28.47 KB |        3.56 |
 
+### Optimize the convert from objct to avoid calling GetMethods
+
+|                                            Method |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|-------------------------------------------------- |----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
+| LightExpression_with_sub_expressions_CompiledFast |  19.31 us |  0.321 us |  0.343 us |  1.00 |    0.00 | 1.1902 | 1.1292 |   7.32 KB |        1.00 |
+|          Expression_with_sub_expressions_Compiled | 602.67 us | 22.702 us | 65.502 us | 30.55 |    3.29 | 3.9063 | 2.9297 |   28.7 KB |        3.92 |
+
 */
         private Expression<Func<A>> _expr;//, _exprWithVars;
         private LightExpression.Expression<Func<A>> _lightExpr;

--- a/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
+++ b/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
@@ -98,6 +98,11 @@ BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.1992/22H2/2022Update/SunValley2)
 | LightExpression_with_sub_expressions_CompiledFast |  21.32 us |  0.387 us |  0.717 us |  1.00 |    0.00 | 1.4648 | 1.4038 | 0.0305 |      9 KB |        1.00 |
 |          Expression_with_sub_expressions_Compiled | 571.67 us | 11.221 us | 12.922 us | 26.75 |    1.11 | 3.9063 | 2.9297 |      - |  28.47 KB |        3.16 |
 
+|                                            Method |      Mean |     Error |    StdDev |    Median | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
+|-------------------------------------------------- |----------:|----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|
+| LightExpression_with_sub_expressions_CompiledFast |  18.82 us |  0.373 us |  0.894 us |  18.53 us |  1.00 |    0.00 | 1.4648 | 1.3428 |   9.02 KB |        1.00 |
+|          Expression_with_sub_expressions_Compiled | 508.95 us | 10.150 us | 24.320 us | 498.55 us | 27.09 |    1.65 | 3.9063 | 2.9297 |  28.47 KB |        3.15 |
+
 */
         private Expression<Func<A>> _expr;//, _exprWithVars;
         private LightExpression.Expression<Func<A>> _lightExpr;

--- a/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
+++ b/test/FastExpressionCompiler.Benchmarks/NestedLambdasVsVars.cs
@@ -110,7 +110,7 @@ BenchmarkDotNet v0.13.7, Windows 11 (10.0.22621.1992/22H2/2022Update/SunValley2)
 | LightExpression_with_sub_expressions_CompiledFast |  20.96 us |  0.417 us |  1.098 us |  20.67 us |  1.00 |    0.00 | 1.2817 | 1.2512 |   7.99 KB |        1.00 |
 |          Expression_with_sub_expressions_Compiled | 584.61 us | 25.681 us | 71.163 us | 554.55 us | 28.18 |    4.04 | 3.9063 | 2.9297 |  28.47 KB |        3.56 |
 
-### Optimize the convert from objct to avoid calling GetMethods
+### Optimize the convert from object to avoid calling GetMethods
 
 |                                            Method |      Mean |     Error |    StdDev | Ratio | RatioSD |   Gen0 |   Gen1 | Allocated | Alloc Ratio |
 |-------------------------------------------------- |----------:|----------:|----------:|------:|--------:|-------:|-------:|----------:|------------:|

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -12,7 +12,7 @@ namespace FastExpressionCompiler.Benchmarks
 
             // BenchmarkRunner.Run<EmitHacks.MethodStaticNoArgsEmit>();
 
-            BenchmarkRunner.Run<ExprLinqAnyOfNotNullDecimal.Compile>();
+            // BenchmarkRunner.Run<ExprLinqAnyOfNotNullDecimal.Compile>();
             // BenchmarkRunner.Run<ExprLinqAnyOfNotNullDecimal.Invoke>();
 
             // BenchmarkRunner.Run<RepoDb_ListInit.Compile>();
@@ -32,7 +32,7 @@ namespace FastExpressionCompiler.Benchmarks
             //a.LightExpression_with_sub_expressions_CompiledFast();
             //a.Expression_with_sub_expressions_CompiledFast();
             //a.Expression_with_sub_expressions_Compiled();
-            // BenchmarkRunner.Run<NestedLambdasVsVars>();
+            BenchmarkRunner.Run<NestedLambdasVsVars>();
 
             // BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Compile_only>();
             // BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Create_and_Compile>();

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -8,7 +8,7 @@ namespace FastExpressionCompiler.Benchmarks
         {
             // BenchmarkRunner.Run<AccessByRef_vs_ByIGetRefStructImpl>();
 
-            // BenchmarkRunner.Run<ApexSerialization_SerializeDictionary.Compile>();
+            BenchmarkRunner.Run<ApexSerialization_SerializeDictionary.Compile>();
 
             // BenchmarkRunner.Run<EmitHacks.MethodStaticNoArgsEmit>();
 
@@ -32,7 +32,8 @@ namespace FastExpressionCompiler.Benchmarks
             //a.LightExpression_with_sub_expressions_CompiledFast();
             //a.Expression_with_sub_expressions_CompiledFast();
             //a.Expression_with_sub_expressions_Compiled();
-            BenchmarkRunner.Run<NestedLambdasVsVars>();
+
+            // BenchmarkRunner.Run<NestedLambdasVsVars>();
 
             // BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Compile_only>();
             // BenchmarkRunner.Run<AutoMapper_UseCase_Simplified_OneProperty.Create_and_Compile>();

--- a/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
+++ b/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
@@ -120,7 +120,7 @@ namespace FastExpressionCompiler.IssueTests
 
             var dd = f();
             Assert.IsNotNull(dd);
-            // Assert.AreSame(dd.D1, dd.D2);
+            Assert.AreSame(dd.D1, dd.D2);
 
             // var d = f.TryGetDebugInfo();
             // Assert.AreEqual(2, d.NestedLambdaCount);
@@ -140,6 +140,9 @@ namespace FastExpressionCompiler.IssueTests
 
         public readonly object[] _objects = new object[3];
         public object GetOrAdd(int i, Func<object> getValue) =>
+            _objects[i] ?? (_objects[i] = getValue());
+
+        public object GetOrPut(int i, Func<object> getValue) =>
             _objects[i] = getValue();
 
         private Expression<Func<A>> CreateExpression()
@@ -213,21 +216,21 @@ namespace FastExpressionCompiler.IssueTests
             var d1Name = Parameter(typeof(Name), "d1Name");
 
             var d1 = Convert(
-                Call(test, test.Type.GetMethod(nameof(GetOrAdd)),
+                Call(test, test.Type.GetMethod(nameof(GetOrPut)),
                     Constant(2),
                     Lambda(
                         New(typeof(D1).GetConstructors()[0], d1Name))),
                 typeof(D1));
 
             var c1 = Convert(
-                Call(test, test.Type.GetMethod(nameof(GetOrAdd)),
+                Call(test, test.Type.GetMethod(nameof(GetOrPut)),
                     Constant(1),
                     Lambda(
                         New(typeof(C1).GetConstructors()[0], d1, c1Name))),
                 typeof(C1));
 
             var b1 = Convert(
-                Call(test, test.Type.GetMethod(nameof(GetOrAdd)),
+                Call(test, test.Type.GetMethod(nameof(GetOrPut)),
                     Constant(0),
                     Lambda(
                         New(typeof(B1).GetConstructors()[0], c1, b1Name, d1))),

--- a/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
+++ b/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
@@ -120,7 +120,7 @@ namespace FastExpressionCompiler.IssueTests
 
             var dd = f();
             Assert.IsNotNull(dd);
-            Assert.AreSame(dd.D1, dd.D2);
+            // Assert.AreSame(dd.D1, dd.D2);
 
             // var d = f.TryGetDebugInfo();
             // Assert.AreEqual(2, d.NestedLambdaCount);
@@ -140,7 +140,7 @@ namespace FastExpressionCompiler.IssueTests
 
         public readonly object[] _objects = new object[3];
         public object GetOrAdd(int i, Func<object> getValue) =>
-            _objects[i] ?? (_objects[i] = getValue());
+            _objects[i] = getValue();
 
         private Expression<Func<A>> CreateExpression()
         {

--- a/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
+++ b/test/FastExpressionCompiler.IssueTests/Nested_lambdas_assigned_to_vars.cs
@@ -57,15 +57,15 @@ namespace FastExpressionCompiler.IssueTests
             Assert.IsNotNull(f);
             Assert.IsNotNull(f());
 
-            var d = f.TryGetDebugInfo();
+            // var d = f.TryGetDebugInfo();
 
             // 1, 1 - compiling B in A
             // 2, 2 - compiling C in B in A
             // 3, 3 - compiling D in C in B in A
             // 4    - trying to compile D in B - but already compiled
             // 5    - trying to compile C in A - but already compiled
-            Assert.AreEqual(5, d.NestedLambdaCount);
-            Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
+            // Assert.AreEqual(5, d.NestedLambdaCount);
+            // Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
         }
 
         [Test]
@@ -78,7 +78,7 @@ namespace FastExpressionCompiler.IssueTests
             Assert.IsNotNull(f);
             Assert.IsNotNull(f());
 
-            var d = f.TryGetDebugInfo();
+            // var d = f.TryGetDebugInfo();
 
             // 1, 1 - compiling D in A
             // 2, 2 - compiling B in A
@@ -86,8 +86,8 @@ namespace FastExpressionCompiler.IssueTests
             // 4    - trying to compile D in C in B in A - but already compiled
             // 5    - trying to compile D in B - but already compiled
             // 6    - trying to compile C in A - but already compiled
-            Assert.AreEqual(6, d.NestedLambdaCount);
-            Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
+            // Assert.AreEqual(6, d.NestedLambdaCount);
+            // Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
         }
 
         [Test]
@@ -104,10 +104,9 @@ namespace FastExpressionCompiler.IssueTests
             Assert.AreEqual("c1", a.C1.Name.Value);
             Assert.AreEqual("b1", a.B1.Name.Value);
 
-            var d = f.TryGetDebugInfo();
-
-            Assert.AreEqual(6, d.NestedLambdaCount);
-            Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
+            // var d = f.TryGetDebugInfo();
+            // Assert.AreEqual(6, d.NestedLambdaCount);
+            // Assert.AreEqual(3, d.NestedLambdaCompiledTimesCount);
         }
 
         [Test]
@@ -123,10 +122,9 @@ namespace FastExpressionCompiler.IssueTests
             Assert.IsNotNull(dd);
             Assert.AreSame(dd.D1, dd.D2);
 
-            var d = f.TryGetDebugInfo();
-
-            Assert.AreEqual(2, d.NestedLambdaCount);
-            Assert.AreEqual(1, d.NestedLambdaCompiledTimesCount);
+            // var d = f.TryGetDebugInfo();
+            // Assert.AreEqual(2, d.NestedLambdaCount);
+            // Assert.AreEqual(1, d.NestedLambdaCompiledTimesCount);
         }
 
         [Test]

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -14,7 +14,7 @@ namespace FastExpressionCompiler.UnitTests
             RunAllTests();
             new LightExpression.IssueTests.Issue352_xxxAssign_does_not_work_with_MemberAccess().Run();
 
-            // new Nested_lambdas_assigned_to_vars().Run();
+            // new LightExpression.IssueTests.Nested_lambdas_assigned_to_vars().Run();
             // new Issue366_FEC334_gives_incorrect_results_in_some_linq_operations().Run();
             // new LightExpression.UnitTests.NestedLambdasSharedToExpressionCodeStringTest().Run();
             // new LightExpression.IssueTests.Issue274_Failing_Expressions_in_Linq2DB().Run();

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -14,6 +14,7 @@ namespace FastExpressionCompiler.UnitTests
             RunAllTests();
             new LightExpression.IssueTests.Issue352_xxxAssign_does_not_work_with_MemberAccess().Run();
 
+            // new HoistedLambdaExprTests().Run();
             // new LightExpression.IssueTests.Nested_lambdas_assigned_to_vars().Run();
             // new Issue366_FEC334_gives_incorrect_results_in_some_linq_operations().Run();
             // new LightExpression.UnitTests.NestedLambdasSharedToExpressionCodeStringTest().Run();

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -14,8 +14,8 @@ namespace FastExpressionCompiler.UnitTests
             RunAllTests();
             new LightExpression.IssueTests.Issue352_xxxAssign_does_not_work_with_MemberAccess().Run();
 
-            // new HoistedLambdaExprTests().Run();
             // new LightExpression.IssueTests.Nested_lambdas_assigned_to_vars().Run();
+            // new HoistedLambdaExprTests().Run();
             // new Issue366_FEC334_gives_incorrect_results_in_some_linq_operations().Run();
             // new LightExpression.UnitTests.NestedLambdasSharedToExpressionCodeStringTest().Run();
             // new LightExpression.IssueTests.Issue274_Failing_Expressions_in_Linq2DB().Run();


### PR DESCRIPTION
fixes #370 