### PR TITLE
ToCSharpCode: Output null instead of default when possible

### DIFF
--- a/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
@@ -31,6 +31,30 @@ namespace FastExpressionCompiler.UnitTests
             Assert.AreEqual(typeof(A<string>), f());
         }
 
+        [Test]
+        public void Outputs_default_null_for_reference_types()
+        {
+            Assert.AreEqual("(string)null;", Constant(null, typeof(string)).ToCSharpString());
+            Assert.AreEqual("(string)null;", Default(typeof(string)).ToCSharpString());
+            Assert.AreEqual("(List<string>)null;", Constant(null, typeof(System.Collections.Generic.List<string>)).ToCSharpString());
+            Assert.AreEqual("(List<string>)null;", Default(typeof(System.Collections.Generic.List<string>)).ToCSharpString());
+            Assert.AreEqual("(int?)null;", Constant(null, typeof(int?)).ToCSharpString());
+            Assert.AreEqual("(int?)null;", Default(typeof(int?)).ToCSharpString());
+
+            Assert.AreEqual("default(int);", Default(typeof(int)).ToCSharpString());
+
+            var block = Block(
+                new[] { Variable(typeof(int), "integer"), Variable(typeof(int?), "maybe_integer"), Variable(typeof(string), "str") },
+                Empty()
+            );
+            Assert.AreEqual("""
+
+                int integer = default;
+                int? maybe_integer = null;
+                string str = null;;
+                """, block.ToCSharpString());
+        }
+
         class A<X> {}
     }
 }


### PR DESCRIPTION
Instead of writing `default(string)` or `default(int?)`, it now prints `(string)null` / `(int?)null`. Non-nullable values types still use default(int).

I find it quite confusing to see `default(SomeType)` even for reference types, especially when I don't remember if `SomeType` is struct or class. I think using `null` for reference types makes the printed code more similar to what people usually write and see.

The type clarity (and verbosity) is not reduced due to the explicit cast.