### PR TITLE
ToCSharpString: fix TypeEqual expression

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -7170,8 +7170,19 @@ namespace FastExpressionCompiler
                     {
                         var x = (TypeBinaryExpression)e;
                         sb.Append('(');
-                        x.Expression.ToCSharpString(sb, lineIdent, stripNamespace, printType, identSpaces, notRecognizedToCode);
-                        sb.Append(" is ").Append(x.TypeOperand.ToCode(stripNamespace, printType));
+                        // Use C# `is T` even for TypeEqual if the two are equivalent (this syntax is nicer)
+                        // IsSealed returns true for arrays, but arrays are cursed and don't behave like sealed classes (`new string[0] is object[]`, and even `new int[0] is uint[]`)
+                        if (x.NodeType == ExpressionType.TypeIs || (x.TypeOperand.IsSealed && !x.TypeOperand.IsArray))
+                        {
+                            x.Expression.ToCSharpString(sb, lineIdent, stripNamespace, printType, identSpaces, notRecognizedToCode);
+                            sb.Append(" is ").Append(x.TypeOperand.ToCode(stripNamespace, printType));
+                        }
+                        else
+                        {
+                            x.Expression.ToCSharpString(sb, lineIdent, stripNamespace, printType, identSpaces, notRecognizedToCode);
+                            sb.Append(".GetType() == typeof(").Append(x.TypeOperand.ToCode(stripNamespace, printType)).Append(')');
+
+                        }
                         return sb.Append(')');
                     }
                 case ExpressionType.Coalesce:

--- a/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/ToCSharpStringTests.cs
@@ -31,6 +31,21 @@ namespace FastExpressionCompiler.UnitTests
             Assert.AreEqual(typeof(A<string>), f());
         }
 
+        [Test]
+        public void Outputs_type_equals()
+        {
+            var p = Parameter(typeof(object), "p");
+            var eSealed = TypeEqual(p, typeof(string));
+            var eStruct = TypeEqual(p, typeof(int));
+            var eArray = TypeEqual(p, typeof(object[]));
+            var eOpen = TypeEqual(p, typeof(System.Collections.Generic.List<string>));
+
+            Assert.AreEqual("(p is string);", eSealed.ToCSharpString());
+            Assert.AreEqual("(p is int);", eStruct.ToCSharpString());
+            Assert.AreEqual("(p.GetType() == typeof(object[]));", eArray.ToCSharpString());
+            Assert.AreEqual("(p.GetType() == typeof(List<string>));", eOpen.ToCSharpString());
+        }
+
         class A<X> {}
     }
 }


### PR DESCRIPTION
Output this expression same as before, if
TypeIs and TypeEqual are equivalent (type cannot have derived classes); otherwise as a.GetType() == typeof(B)