### PR TITLE
Still not work with HasFlag

### DIFF
--- a/test/FastExpressionCompiler.IssueTests/Issue374_CompileFast_doesnot_work_with_HasFlag.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue374_CompileFast_doesnot_work_with_HasFlag.cs
@@ -46,8 +46,8 @@ public class Issue374_CompileFast_doesnot_work_with_HasFlag : ITest
 
         b1 = new Bar { Foo = Foo.Green };
         b2 = new Bar { Foo = Foo.Red | Foo.Blue };
-        Assert.IsTrue(fs(b1));
-        Assert.IsFalse(fs(b2));
+        Assert.IsTrue(ff(b1));
+        Assert.IsFalse(ff(b2));
     }
 
     [Flags]


### PR DESCRIPTION
When I tried to update to version `4.0.0` I discovered that the problem with `HasFlag` was probably not resolved. 

![image](https://github.com/dadhi/FastExpressionCompiler/assets/9804340/5f3602c3-6448-4bfa-840b-5826675443af)

The error still occurs locally and in the tests, it seems to me, there is a typo, because `CompileSys` is checked twice.
