### PR TITLE
Add (back?) support for Rethrow expression

### DIFF
--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -1521,6 +1521,10 @@ namespace FastExpressionCompiler.LightExpression
         /// <summary>Creates a UnaryExpression that represents a throwing of an exception with a given type.</summary>
         public static UnaryExpression Throw(Expression value, Type type) =>
             new TypedUnaryExpression(ExpressionType.Throw, value, type);
+        
+        /// <summary> Creates a <see cref="UnaryExpression"/> that represents a rethrowing of an exception in a catch block. </summary>
+        public static UnaryExpression Rethrow(Type type) =>
+            new TypedUnaryExpression(ExpressionType.Throw, null, type);
 
         public static LabelExpression Label(LabelTarget target) =>
             new LabelExpression(target);

--- a/src/FastExpressionCompiler.LightExpression/Expression.cs
+++ b/src/FastExpressionCompiler.LightExpression/Expression.cs
@@ -2281,7 +2281,7 @@ namespace FastExpressionCompiler.LightExpression
                 case ExpressionType.Quote: return SysExpr.Quote(Operand.ToExpression(ref exprsConverted));
                 case ExpressionType.UnaryPlus: return SysExpr.UnaryPlus(Operand.ToExpression(ref exprsConverted));
                 case ExpressionType.Unbox: return SysExpr.Unbox(Operand.ToExpression(ref exprsConverted), Type);
-                case ExpressionType.Throw: return SysExpr.Throw(Operand.ToExpression(ref exprsConverted), Type);
+                case ExpressionType.Throw: return SysExpr.Throw(Operand?.ToExpression(ref exprsConverted), Type);
                 case ExpressionType.TypeAs: return SysExpr.TypeAs(Operand.ToExpression(ref exprsConverted), Type);
                 case ExpressionType.Not: return SysExpr.Not(Operand.ToExpression(ref exprsConverted));
                 default:

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -7377,8 +7377,13 @@ namespace FastExpressionCompiler
                                     return sb;
 
                                 case ExpressionType.Throw:
-                                    sb.Append("throw ");
-                                    return op.ToCSharpString(sb, lineIdent, stripNamespace, printType, identSpaces, notRecognizedToCode).Append(';');
+                                    if (op is null)
+                                        return sb.Append("throw;");
+                                    else
+                                    {
+                                        sb.Append("throw ");
+                                        return op.ToCSharpString(sb, lineIdent, stripNamespace, printType, identSpaces, notRecognizedToCode).Append(';');
+                                    }
 
                                 case ExpressionType.Unbox: // output it as the cast
                                     sb.Append("((").Append(e.Type.ToCode(stripNamespace, printType)).Append(')');

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -1482,6 +1482,8 @@ namespace FastExpressionCompiler
                     default:
                         if (expr is UnaryExpression unaryExpr)
                         {
+                            if (unaryExpr.Operand is null)
+                                return r;
                             expr = unaryExpr.Operand;
                             continue;
                         }
@@ -2054,9 +2056,17 @@ namespace FastExpressionCompiler
 
                         case ExpressionType.Throw:
                             {
-                                if (!TryEmit(((UnaryExpression)expr).Operand, paramExprs, il, ref closure, setup, parent & ~ParentFlags.IgnoreResult))
-                                    return false;
-                                il.Demit(OpCodes.Throw);
+                                var throwExpr = (UnaryExpression)expr;
+                                if (throwExpr.Operand is null)
+                                {
+                                    il.Demit(OpCodes.Rethrow);
+                                }
+                                else
+                                {
+                                    if (!TryEmit(throwExpr.Operand, paramExprs, il, ref closure, setup, parent & ~ParentFlags.IgnoreResult))
+                                        return false;
+                                    il.Demit(OpCodes.Throw);
+                                }
                                 return true;
                             }
 

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -31,8 +31,12 @@ namespace FastExpressionCompiler.UnitTests
             Can_return_nested_catch_block_result();
             Can_return_from_try_block_using_goto_to_label_with_default_value();
             Can_return_from_try_block_using_goto_to_label_with_the_more_code_after_label();
+            Can_rethrow();
+            Can_rethrow_void();
+            Can_rethrow_or_wrap();
+            Can_rethrow_or_suppress();
 
-            return 13;
+            return 17;
         }
 
         [Test]

--- a/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/TryCatchTests.cs
@@ -397,5 +397,153 @@ namespace FastExpressionCompiler.UnitTests
             Assert.IsNotNull(func);
             Assert.AreEqual("From inner Catch block", func());
         }
+
+        [Test]
+        public void Can_rethrow()
+        {
+            var exceptions = new System.Collections.Generic.List<Exception>();
+            var pFn = Parameter(typeof(Func<string>), "fn");
+            var pEx = Parameter(typeof(Exception), "ex");
+            var expr = Lambda<Func<Func<string>, string>>(
+                TryCatch(
+                    Invoke(pFn),
+                    Catch(
+                        pEx,
+                        Block(
+                            Invoke(Constant(new Action<Exception>(exceptions.Add)), pEx),
+                            Rethrow(typeof(string))
+                        )
+                    )
+                ),
+                pFn
+            );
+
+            var compiledFast = expr.CompileFast(true, CompilerFlags.ThrowOnNotSupportedExpression);
+            var compiled = expr.CompileSys();
+            compiledFast.PrintIL();
+
+            // no exception
+            Assert.AreEqual("ok", compiledFast(() => "ok"));
+            Assert.AreEqual("ok", compiled(() => "ok"));
+            // rethrown exception
+            Assert.IsEmpty(exceptions);
+            Assert.Throws<ArgumentException>(() => compiledFast(() => { throw new ArgumentException(); }));
+            Assert.That(exceptions, Has.Count.EqualTo(1));
+            Assert.Throws<ArgumentException>(() => compiled(() => { throw new ArgumentException(); }));
+            Assert.That(exceptions, Has.Count.EqualTo(2));
+        }
+
+        [Test]
+        public void Can_rethrow_void()
+        {
+            var pFn = Parameter(typeof(Action), "fn");
+            var pEx = Parameter(typeof(Exception), "ex");
+            var expr = Lambda<Action<Action>>(
+                TryCatch(
+                    Invoke(pFn),
+                    Catch(
+                        pEx,
+                        Rethrow(typeof(void))
+                    )
+                ),
+                pFn
+            );
+
+            var compiledFast = expr.CompileFast(true, CompilerFlags.ThrowOnNotSupportedExpression);
+            var compiled = expr.CompileSys();
+            compiledFast.PrintIL();
+
+            // no exception
+            var executed = 0;
+            compiledFast(() => executed++);
+            Assert.AreEqual(1, executed);
+            compiled(() => executed++);
+            Assert.AreEqual(2, executed);
+            // rethrown exception
+            Assert.Throws<ArgumentException>(() => compiledFast(() => { throw new ArgumentException(); }));
+            Assert.Throws<ArgumentException>(() => compiled(() => { throw new ArgumentException(); }));
+        }
+
+        [Test]
+        public void Can_rethrow_or_wrap()
+        {
+            var pFn = Parameter(typeof(Func<string>), "fn");
+            var pEx = Parameter(typeof(Exception), "ex");
+            var expr = Lambda<Func<Func<string>, string>>(
+                TryCatch(
+                    Invoke(pFn),
+                    Catch(
+                        pEx,
+                        // ex is ArgumentException ? throw : throw new Exception("wrapped", ex);
+                        Condition(
+                            TypeIs(pEx, typeof(ArgumentException)),
+                            Rethrow(typeof(string)),
+                            Throw(
+                                New(typeof(Exception).GetConstructor(new[] { typeof(string), typeof(Exception) }), Constant("wrapped"), pEx),
+                                typeof(string)
+                            )
+                        )
+                    )
+                ),
+                pFn
+            );
+
+            var compiledFast = expr.CompileFast(true, CompilerFlags.ThrowOnNotSupportedExpression);
+            var compiled = expr.CompileSys();
+            compiledFast.PrintIL();
+
+            // no exception
+            Assert.AreEqual("ok", compiledFast(() => "ok"));
+            Assert.AreEqual("ok", compiled(() => "ok"));
+            // rethrown exception
+            Assert.Throws<ArgumentException>(() => compiledFast(() => { throw new ArgumentException(); }));
+            Assert.Throws<ArgumentException>(() => compiled(() => { throw new ArgumentException(); }));
+            // wrapped exception
+            var exception = Assert.Throws<Exception>(() => compiledFast(() => { throw new InvalidOperationException(); }));
+            Assert.AreEqual("wrapped", exception.Message);
+            Assert.IsInstanceOf<InvalidOperationException>(exception.InnerException);
+            exception = Assert.Throws<Exception>(() => compiled(() => { throw new InvalidOperationException(); }));
+            Assert.AreEqual("wrapped", exception.Message);
+            Assert.IsInstanceOf<InvalidOperationException>(exception.InnerException);
+        }
+
+        [Test]
+        public void Can_rethrow_or_suppress()
+        {
+            var pFn = Parameter(typeof(Func<string>), "fn");
+            var pEx = Parameter(typeof(Exception), "ex");
+            var expr = Lambda<Func<Func<string>, string>>(
+                TryCatch(
+                    Invoke(pFn),
+                    Catch(
+                        pEx,
+                        // ex is ArgumentException ? throw : "exception suppressed";
+                        Condition(
+                            TypeIs(pEx, typeof(ArgumentException)),
+                            Rethrow(typeof(string)),
+                            Constant("exception suppressed")
+                        )
+                    )
+                ),
+                pFn
+            );
+
+            var compiledFast = expr.CompileFast(true, CompilerFlags.ThrowOnNotSupportedExpression);
+            var compiled = expr.CompileSys();
+            compiledFast.PrintIL();
+
+            // no exception
+            Assert.AreEqual("ok", compiledFast(() => "ok"));
+            Assert.AreEqual("ok", compiled(() => "ok"));
+            // rethrown exception
+            Assert.Throws<ArgumentException>(() => compiledFast(() => { throw new ArgumentException(); }));
+            Assert.Throws<ArgumentException>(() => compiled(() => { throw new ArgumentException(); }));
+            // caught exception
+            Assert.AreEqual("exception suppressed", compiledFast(() => { throw new InvalidOperationException(); }));
+            Assert.AreEqual("exception suppressed", compiled(() => { throw new InvalidOperationException(); }));
+
+            // throw null;
+        }
+
     }
 }


### PR DESCRIPTION
Linq.Expressions supports rethrow in catch blocks (C# `throw;` statement) by setting the Operand to null.

This is causing exception in FEC as of version 4.0.0, but it somehow worked in previous versions.
I have no idea why, as I couldn't find any handling of rethrows in the older version, but upgrading FEC from 3.4.0-preview-01 to 4.0.0 makes [our](https://github.com/riganti/dotvvm/) tests fail. If you'd like to know which commit did it, I can bisect it, I figured it would be easier to just go add support for it. I guess it somehow worked only by accident :shrug:, it seems that we don't run into the rethrow instruction in our unit tests, we only "needed" it to compile somehow.


So this patch adds proper support for rethrows, including some unit tests. I also added Rethrow function to LightExpression and support to ToCSharpString method