### PR TITLE
DEMIT debug output: print start and end of try/catch/finally blocks and method

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -132,6 +132,10 @@ namespace FastExpressionCompiler
             if ((flags & CompilerFlags.EnableDelegateDebugInfo) != 0)
                 throw new NotSupportedException("The `CompilerFlags.EnableDelegateDebugInfo` is not supported because the debug info is gathered into the closure object which is not allowed for static lambda to be compiled to method.");
 
+#if DEMIT
+            Debug.WriteLine("CompileFastToIL: " + lambdaExpr);
+#endif
+
 #if LIGHT_EXPRESSION
             var paramExprs = lambdaExpr;
 #else
@@ -152,6 +156,9 @@ namespace FastExpressionCompiler
                 return false;
 
             il.Demit(OpCodes.Ret);
+#if DEMIT
+            Debug.WriteLine("Compilation done.");
+#endif
             return true;
         }
 
@@ -470,6 +477,9 @@ namespace FastExpressionCompiler
             Type[] closurePlusParamTypes, Type returnType, CompilerFlags flags)
         {
 #endif
+#if DEMIT
+            Debug.WriteLine("CompileFast: " + bodyExpr.ToCSharpString());
+#endif
             // The method collects the info from the all nested lambdas deep down up-front and de-duplicates the lambdas as well.
             var closureInfo = new ClosureInfo(ClosureStatus.ToBeCollected);
             if (!TryCollectBoundConstants(ref closureInfo, bodyExpr, paramExprs, null, ref closureInfo.NestedLambdas, flags))
@@ -503,6 +513,10 @@ namespace FastExpressionCompiler
             if (!EmittingVisitor.TryEmit(bodyExpr, paramExprs, il, ref closureInfo, flags, parent))
                 return null;
             il.Demit(OpCodes.Ret);
+
+#if DEMIT
+            Debug.WriteLine("Compilation done.");
+#endif
 
             return method.CreateDelegate(delegateType, closure);
         }

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -2408,6 +2408,9 @@ namespace FastExpressionCompiler
                 CompilerFlags setup, ParentFlags parent)
 #endif
             {
+#if DEMIT
+                Debug.WriteLine("try {");
+#endif
                 il.BeginExceptionBlock();
 
                 if (!TryEmit(tryExpr.Body, paramExprs, il, ref closure, setup, parent))
@@ -2432,6 +2435,9 @@ namespace FastExpressionCompiler
                     // at the beginning of catch the Exception value is on the stack,
                     // we will store into local variable.
                     var exVarExpr = catchBlock.Variable;
+#if DEMIT
+                Debug.WriteLine($"}} catch {{");
+#endif
                     if (exVarExpr != null)
                     {
                         var exVarIndex = il.GetNextLocalVarIndex(exVarExpr.Type);
@@ -2452,12 +2458,19 @@ namespace FastExpressionCompiler
                 var finallyExpr = tryExpr.Finally;
                 if (finallyExpr != null)
                 {
+#if DEMIT
+                Debug.WriteLine("} finally {" + finallyExpr);
+#endif
                     il.BeginFinallyBlock();
                     if (!TryEmit(finallyExpr, paramExprs, il, ref closure, setup, parent))
                         return false;
                 }
 
                 il.EndExceptionBlock();
+
+#if DEMIT
+                Debug.WriteLine("}");
+#endif
 
                 if (returnsResult)
                     EmitLoadLocalVariable(il, resultVarIndex);

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -132,10 +132,6 @@ namespace FastExpressionCompiler
             if ((flags & CompilerFlags.EnableDelegateDebugInfo) != 0)
                 throw new NotSupportedException("The `CompilerFlags.EnableDelegateDebugInfo` is not supported because the debug info is gathered into the closure object which is not allowed for static lambda to be compiled to method.");
 
-#if DEMIT
-            Debug.WriteLine("CompileFastToIL: " + lambdaExpr);
-#endif
-
 #if LIGHT_EXPRESSION
             var paramExprs = lambdaExpr;
 #else
@@ -156,9 +152,6 @@ namespace FastExpressionCompiler
                 return false;
 
             il.Demit(OpCodes.Ret);
-#if DEMIT
-            Debug.WriteLine("Compilation done.");
-#endif
             return true;
         }
 
@@ -477,9 +470,6 @@ namespace FastExpressionCompiler
             Type[] closurePlusParamTypes, Type returnType, CompilerFlags flags)
         {
 #endif
-#if DEMIT
-            Debug.WriteLine("CompileFast: " + bodyExpr.ToCSharpString());
-#endif
             // The method collects the info from the all nested lambdas deep down up-front and de-duplicates the lambdas as well.
             var closureInfo = new ClosureInfo(ClosureStatus.ToBeCollected);
             if (!TryCollectBoundConstants(ref closureInfo, bodyExpr, paramExprs, null, ref closureInfo.NestedLambdas, flags))
@@ -513,10 +503,6 @@ namespace FastExpressionCompiler
             if (!EmittingVisitor.TryEmit(bodyExpr, paramExprs, il, ref closureInfo, flags, parent))
                 return null;
             il.Demit(OpCodes.Ret);
-
-#if DEMIT
-            Debug.WriteLine("Compilation done.");
-#endif
 
             return method.CreateDelegate(delegateType, closure);
         }


### PR DESCRIPTION
The debug output is very useful, but in my last debugging session I was lacking the information about try/catch/finally blocks and the method boundaries (I had multiple compile invocations in one test).

This PR adds the information, it's in 2 commits, feel free to merge just one of them or edit it in any way. I can always apply the patch when I get to debug something, but I think it might be useful for you and others.

* try blocks are delimited by `try {`, `} catch (myVariable) {`, `} finally {` and end with `}`
* methods now start with `CompileFast[ToIL]: {expression.ToCSharpString()}` and end with `Compilation done.` message