### PR TITLE
#394 - Fixed check of right operand for operators

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -4858,7 +4858,7 @@ namespace FastExpressionCompiler
                         if (m.IsSpecialName && m.IsStatic && m.Name == methodName)
                         {
                             var ps = m.GetParameters();
-                            if (ps.Length == 2 && ps[0].ParameterType == leftOpType && ps[1].ParameterType == leftOpType)
+                            if (ps.Length == 2 && ps[0].ParameterType == leftOpType && ps[1].ParameterType == rightOpType)
                             {
                                 var ok = EmitMethodCall(il, m);
                                 if (leftIsNullable)

--- a/test/FastExpressionCompiler.UnitTests/EqualityOperatorsTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/EqualityOperatorsTests.cs
@@ -52,6 +52,19 @@ namespace FastExpressionCompiler.UnitTests
         }
 
         [Test]
+        public void Implicit_equal()
+        {
+            Expression<Func<EntityWithImplicitEquality, Entity, bool>> e =
+                (ewe, entity) => ewe == entity;
+
+            var f = e.CompileFast(true);
+            var entityWithEquals = new EntityWithImplicitEquality { AvailableDate = DateTime.Now };
+            var entity = new Entity { AvailableDate = entityWithEquals.AvailableDate };
+            var value = f(entityWithEquals, entity);
+            Assert.IsTrue(value);
+        }
+
+        [Test]
         public void Complex_expression_with_DateTime_Strings_and_Int()
         {
             var dtNow = DateTime.Now;
@@ -110,6 +123,37 @@ namespace FastExpressionCompiler.UnitTests
             public string StartTime { get; set; }
             public string EndTime { get; set; }
             public DateTime AvailableDate { get; set; }
+        }
+
+
+        public class EntityWithImplicitEquality
+        {
+            public DateTime AvailableDate { get; set; }
+
+            public static bool operator ==(EntityWithImplicitEquality ewe, Entity entity) => ewe?.AvailableDate == entity?.AvailableDate;
+            public static bool operator !=(EntityWithImplicitEquality ewe, Entity entity) => ewe?.AvailableDate.Equals(entity?.AvailableDate) != true;
+
+            public override bool Equals(object obj)
+            {
+                if (ReferenceEquals(this, obj))
+                {
+                    return true;
+                }
+
+                if (ReferenceEquals(obj, null))
+                {
+                    return false;
+                }
+
+                if (obj is EntityWithImplicitEquality other)
+                    return AvailableDate == other.AvailableDate;
+                return false;
+            }
+
+            public override int GetHashCode()
+            {
+                return AvailableDate.GetHashCode();
+            }
         }
     }
 }


### PR DESCRIPTION
Changed the type check for the right operand on operators (==, !=,<=, <, >=, >).

Now an operator like
```c#
public static bool operator ==(MyType me, OtherType other) => ...
```
will be compiled correctly, when calling
```c#
(MyType me, OtherType other) => me == other;
```