### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,41 @@
+name: Build
+
+on:
+  push:
+    branches: [ master ]
+    paths-ignore:
+    - 'readme.md'
+
+  pull_request:
+    branches: [ master ]
+    paths-ignore:
+    - 'readme.md'
+
+jobs:
+  build:
+
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-latest]
+
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+
+    - name: Build
+      run: dotnet build -c:Release
+    
+    - name: Tests - Latest TFM
+      run: dotnet run --no-build -c:Release -f:net9.0 --project test/FastExpressionCompiler.TestsRunner/FastExpressionCompiler.TestsRunner.csproj
+
+    - if: matrix.os == 'windows-latest'
+      name: Tests - net472
+      run: dotnet run --no-build -c:Release --project test/FastExpressionCompiler.TestsRunner.Net472

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,48 @@
+name: Publish
+
+on:
+  push:
+    tags: 
+      - 'v*.*.*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    env:
+      DOTNET_NOLOGO: true
+      DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
+      DOTNET_CLI_TELEMETRY_OPTOUT: true
+
+    steps:
+    - uses: actions/checkout@v4
+    - uses: actions/setup-dotnet@v4
+      with:
+        global-json-file: global.json
+    
+    - name: Build
+      run: dotnet build --configuration Release
+
+    - name: Make Internal
+      shell: pwsh
+      run: ./BuildScripts/MakeInternal.ps1
+
+    - name: Pack with dotnet
+      run: |
+        arrTag=(${GITHUB_REF//\// })
+        VERSION="${arrTag[2]}"
+        VERSION="${VERSION//v}"
+        echo "$VERSION"
+        
+        dotnet pack --no-build --output artifacts -p:Version=$VERSION -p:ContinuousIntegrationBuild=True ./nuspecs/FastExpressionCompiler.src.nuspec
+        dotnet pack --no-build --output artifacts -p:Version=$VERSION -p:ContinuousIntegrationBuild=True ./nuspecs/FastExpressionCompiler.LightExpression.src.nuspec
+        dotnet pack --no-build --output artifacts -p:Version=$VERSION -p:ContinuousIntegrationBuild=True ./nuspecs/FastExpressionCompiler.Internal.src.nuspec
+        dotnet pack --no-build --output artifacts -p:Version=$VERSION -p:ContinuousIntegrationBuild=True ./nuspecs/FastExpressionCompiler.LightExpression.Internal.src.nuspec
+
+    - uses: actions/upload-artifact@v4
+      with:
+        name: Packages
+        path: ./artifacts
+        
+    # - name: Push with dotnet
+    #   run: dotnet nuget push artifacts/*.nupkg --api-key ${{ secrets.NUGET_API_KEY }} --source https://api.nuget.org/v3/index.json

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "latestMajor"
+  }
+}


### PR DESCRIPTION
This creates the build workflow which is triggered on new PRs targeting `master` and when a commit is done on `master.

It also has a workflow for publishing the packages but it's not final. This can be tested freely as it's not publishing the packages it builds but still assigns then as artifacts to be able to look at the results. It's using the `va.b.c` tag to set the version, but this can be removed to reuse the current logic (defined in source).