### PR TITLE
@wip issue468

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -8656,10 +8656,6 @@ namespace FastExpressionCompiler
                                     false, lineIndent, stripNamespace, printType, indentSpaces, notRecognizedToCode);
                             }
 
-                            // remove the parens from the simple comparisons and ops between params, variables and constants
-                            if (b.Left.IsParamOrConstantOrDefault() && b.Right.IsParamOrConstantOrDefault())
-                                avoidParens = true;
-
                             sb = !avoidParens ? sb.Append('(') : sb;
                             b.Left.ToCSharpExpression(sb, EnclosedIn.ParensByDefault, ref named,
                                 false, lineIndent, stripNamespace, printType, indentSpaces, notRecognizedToCode);

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -122,9 +122,9 @@ namespace FastExpressionCompiler
             (TDelegate)(TryCompileBoundToFirstClosureParam(
                 typeof(TDelegate) == typeof(Delegate) ? lambdaExpr.Type : typeof(TDelegate), lambdaExpr.Body,
 #if LIGHT_EXPRESSION
-                lambdaExpr, RentOrNewClosureTypeToParamTypes(lambdaExpr),
+                lambdaExpr,
 #else
-                lambdaExpr.Parameters, RentOrNewClosureTypeToParamTypes(lambdaExpr.Parameters),
+                lambdaExpr.Parameters,
 #endif
                 lambdaExpr.ReturnType, flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys()));
 
@@ -163,9 +163,9 @@ namespace FastExpressionCompiler
         public static Delegate CompileFast(this LambdaExpression lambdaExpr, bool ifFastFailedReturnNull = false, CompilerFlags flags = CompilerFlags.Default) =>
             (Delegate)TryCompileBoundToFirstClosureParam(lambdaExpr.Type, lambdaExpr.Body,
 #if LIGHT_EXPRESSION
-            lambdaExpr, RentOrNewClosureTypeToParamTypes(lambdaExpr),
+            lambdaExpr,
 #else
-            lambdaExpr.Parameters, RentOrNewClosureTypeToParamTypes(lambdaExpr.Parameters),
+            lambdaExpr.Parameters,
 #endif
             lambdaExpr.ReturnType, flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
@@ -215,7 +215,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                _closureAsASingleParamType, typeof(R), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
+                typeof(R), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
         public static Func<T1, R> CompileFast<T1, R>(this Expression<Func<T1, R>> lambdaExpr,
@@ -226,7 +226,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-            new[] { typeof(ArrayClosure), typeof(T1) }, typeof(R), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
+            typeof(R), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to TDelegate type. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
         public static Func<T1, T2, R> CompileFast<T1, T2, R>(this Expression<Func<T1, T2, R>> lambdaExpr,
@@ -237,7 +237,6 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2) },
                 typeof(R), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -249,7 +248,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-            new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3) }, typeof(R), flags)
+            typeof(R), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to TDelegate type. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -261,7 +260,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4) }, typeof(R), flags)
+                typeof(R), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -273,7 +272,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) }, typeof(R), flags)
+                typeof(R), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -285,7 +284,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6) }, typeof(R), flags)
+                typeof(R), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -296,7 +295,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-            _closureAsASingleParamType, typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
+            typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
         public static Action<T1> CompileFast<T1>(this Expression<Action<T1>> lambdaExpr,
@@ -307,7 +306,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-            new[] { typeof(ArrayClosure), typeof(T1) }, typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
+            typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
         public static Action<T1, T2> CompileFast<T1, T2>(this Expression<Action<T1, T2>> lambdaExpr,
@@ -318,7 +317,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-            new[] { typeof(ArrayClosure), typeof(T1), typeof(T2) }, typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
+            typeof(void), flags) ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
         public static Action<T1, T2, T3> CompileFast<T1, T2, T3>(this Expression<Action<T1, T2, T3>> lambdaExpr,
@@ -329,7 +328,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3) }, typeof(void), flags)
+                typeof(void), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -341,7 +340,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4) }, typeof(void), flags)
+                typeof(void), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -353,7 +352,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5) }, typeof(void), flags)
+                typeof(void), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         /// <summary>Compiles lambda expression to delegate. Use ifFastFailedReturnNull parameter to Not fallback to Expression.Compile, useful for testing.</summary>
@@ -365,7 +364,7 @@ namespace FastExpressionCompiler
 #else
                 lambdaExpr.Parameters,
 #endif
-                new[] { typeof(ArrayClosure), typeof(T1), typeof(T2), typeof(T3), typeof(T4), typeof(T5), typeof(T6) }, typeof(void), flags)
+                typeof(void), flags)
             ?? (ifFastFailedReturnNull ? null : lambdaExpr.CompileSys());
 
         #endregion
@@ -375,9 +374,9 @@ namespace FastExpressionCompiler
             where TDelegate : class =>
             (TDelegate)TryCompileBoundToFirstClosureParam(typeof(TDelegate) == typeof(Delegate) ? lambdaExpr.Type : typeof(TDelegate), lambdaExpr.Body,
 #if LIGHT_EXPRESSION
-            lambdaExpr, RentOrNewClosureTypeToParamTypes(lambdaExpr),
+            lambdaExpr,
 #else
-            lambdaExpr.Parameters, RentOrNewClosureTypeToParamTypes(lambdaExpr.Parameters),
+            lambdaExpr.Parameters,
 #endif
             lambdaExpr.ReturnType, flags);
 
@@ -468,25 +467,88 @@ namespace FastExpressionCompiler
             return @delegate;
         }
 
-        private static Delegate CompileNoArgsNew(ConstructorInfo ctor, Type delegateType, Type[] closurePlusParamTypes, Type returnType)
+        private static Delegate CompileNoArgsNew(ConstructorInfo ctor, Type delegateType, Type returnType)
         {
-            var method = new DynamicMethod(string.Empty, returnType, closurePlusParamTypes, typeof(ArrayClosure), true);
+            var method = new DynamicMethod(string.Empty, returnType, Tools.Empty<Type>(), true);
             var il = method.GetILGenerator(16); // 16 is enough for maximum of 3 possible ops
             il.Demit(OpCodes.Newobj, ctor);
             if (returnType == typeof(void))
                 il.Demit(OpCodes.Pop);
             il.Demit(OpCodes.Ret);
-            return method.CreateDelegate(delegateType, EmptyArrayClosure);
+            return method.CreateDelegate(delegateType, null);
         }
 
 #if LIGHT_EXPRESSION
         internal static object TryCompileBoundToFirstClosureParam(Type delegateType, Expression bodyExpr, IParameterProvider paramExprs,
+            Type returnType, CompilerFlags flags)
+        {
+            if (bodyExpr is NoArgsNewClassIntrinsicExpression newNoArgs)
+                return CompileNoArgsNew(newNoArgs.Constructor, delegateType, returnType);
+#else
+        internal static object TryCompileBoundToFirstClosureParam(Type delegateType, Expression bodyExpr, IReadOnlyList<PE> paramExprs,
+            Type returnType, CompilerFlags flags)
+        {
+#endif
+            // The method collects the info from the all nested lambdas deep down up-front and de-duplicates the lambdas as well.
+            var closureInfo = new ClosureInfo(ClosureStatus.ToBeCollected);
+            if (!TryCollectBoundConstants(ref closureInfo, bodyExpr, paramExprs, null, ref closureInfo.NestedLambdas, flags))
+                return null;
+
+            ArrayClosure closure = null;
+            if ((flags & CompilerFlags.EnableDelegateDebugInfo) == 0)
+            {
+                if ((closureInfo.Status & ClosureStatus.HasClosure) != 0)
+                    closure = new ArrayClosure(closureInfo.GetArrayOfConstantsAndNestedLambdas());
+            }
+            else
+            {   // todo: @feature add the debug info to the nested lambdas!
+                var debugExpr = Lambda(delegateType, bodyExpr, paramExprs?.ToReadOnlyList() ?? Tools.Empty<PE>());
+                var constantsAndNestedLambdas = (closureInfo.Status & ClosureStatus.HasClosure) == 0
+                    ? null
+                    : closureInfo.GetArrayOfConstantsAndNestedLambdas();
+                closure = new DebugArrayClosure(constantsAndNestedLambdas, debugExpr);
+            }
+
+            var paramTypes = closure != null
+                ? RentOrNewClosureTypeToParamTypes(paramExprs)
+                : RentOrNewParamTypes(paramExprs);
+
+            var method = closure != null
+                ? new DynamicMethod(string.Empty, returnType, paramTypes, typeof(ArrayClosure), true)
+                : new DynamicMethod(string.Empty, returnType, paramTypes, true);
+
+            // todo: @perf can we just count the Expressions in the TryCollect phase and use it as N * 4 or something?
+            var il = method.GetILGenerator();
+
+            if (closure?.ConstantsAndNestedLambdas != null)
+                EmittingVisitor.EmitLoadConstantsAndNestedLambdasIntoVars(il, ref closureInfo);
+
+            var parent = returnType == typeof(void) ? ParentFlags.IgnoreResult : ParentFlags.LambdaCall;
+            if (returnType.IsByRef)
+                parent |= ParentFlags.ReturnByRef;
+
+            if (!EmittingVisitor.TryEmit(bodyExpr, paramExprs, il, ref closureInfo, flags, parent))
+                return null;
+            il.Demit(OpCodes.Ret);
+
+            var result = method.CreateDelegate(delegateType, closure);
+
+            if (closure != null)
+                ReturnClosureTypeToParamTypesToPool(paramTypes);
+            else
+                ReturnParamTypesToPool(paramTypes);
+
+            return result;
+        }
+
+#if LIGHT_EXPRESSION
+        internal static object TryCompileBoundToFirstClosureParam_OLD(Type delegateType, Expression bodyExpr, IParameterProvider paramExprs,
             Type[] closurePlusParamTypes, Type returnType, CompilerFlags flags)
         {
             if (bodyExpr is NoArgsNewClassIntrinsicExpression newNoArgs)
-                return CompileNoArgsNew(newNoArgs.Constructor, delegateType, closurePlusParamTypes, returnType);
+                return CompileNoArgsNew(newNoArgs.Constructor, delegateType, returnType);
 #else
-        internal static object TryCompileBoundToFirstClosureParam(Type delegateType, Expression bodyExpr, IReadOnlyList<PE> paramExprs,
+        internal static object TryCompileBoundToFirstClosureParam_OLD(Type delegateType, Expression bodyExpr, IReadOnlyList<PE> paramExprs,
             Type[] closurePlusParamTypes, Type returnType, CompilerFlags flags)
         {
 #endif
@@ -576,6 +638,40 @@ namespace FastExpressionCompiler
             var paramCount = closurePlusParamTypes.Length - 1;
             if (paramCount != 0 && paramCount < 8)
                 Interlocked.Exchange(ref _closureTypePlusParamTypesPool[paramCount], closurePlusParamTypes); // todo: @perf we don't need the Interlocked here
+        }
+
+        private static readonly Type[][] _paramTypesPool = new Type[8][];
+
+#if LIGHT_EXPRESSION
+        private static Type[] RentOrNewParamTypes(IParameterProvider paramExprs)
+        {
+            var count = paramExprs.ParameterCount;
+#else
+        private static Type[] RentOrNewParamTypes(IReadOnlyList<PE> paramExprs)
+        {
+            var count = paramExprs.Count;
+#endif
+            if (count == 0)
+                return Tools.Empty<Type>();
+
+            var paramTypes = count < 8 ? (Interlocked.Exchange(ref _paramTypesPool[count - 1], null) ?? new Type[count]) : new Type[count];
+            for (var i = 0; i < count; ++i)
+            {
+                var parameterExpr = paramExprs.GetParameter(i);
+                paramTypes[i] = parameterExpr.IsByRef ? parameterExpr.Type.MakeByRefType() : parameterExpr.Type;
+            }
+            return paramTypes;
+        }
+
+        [MethodImpl((MethodImplOptions)256)]
+        private static void ReturnParamTypesToPool(Type[] paramTypes)
+        {
+            if (paramTypes.Length == 0)
+                return;
+
+            var paramCount = paramTypes.Length - 1;
+            if (paramCount != 0 & paramCount < 8)
+                Interlocked.Exchange(ref _paramTypesPool[paramCount], paramTypes);
         }
 
 #pragma warning disable CS1591 // Missing XML comment for publicly visible type or member
@@ -1734,9 +1830,7 @@ namespace FastExpressionCompiler
 
             if (nestedLambdaBody is NoArgsNewClassIntrinsicExpression newNoArgs)
             {
-                var paramTypes = RentOrNewClosureTypeToParamTypes(nestedLambdaParamExprs);
-                nestedLambdaInfo.Lambda = CompileNoArgsNew(newNoArgs.Constructor, nestedLambdaExpr.Type, paramTypes, nestedReturnType);
-                ReturnClosureTypeToParamTypesToPool(paramTypes);
+                nestedLambdaInfo.Lambda = CompileNoArgsNew(newNoArgs.Constructor, nestedLambdaExpr.Type, nestedReturnType);
                 return true;
             }
 #else

--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -499,6 +499,9 @@ namespace FastExpressionCompiler
             {
                 if ((closureInfo.Status & ClosureStatus.HasClosure) != 0)
                     closure = new ArrayClosure(closureInfo.GetArrayOfConstantsAndNestedLambdas());
+                else
+                    // Marking it so, that the Emit will load the arguments by the proper index, not by +1 when the delegate has a closure as the 0 one
+                    closureInfo.Status |= ClosureStatus.ShouldBeStaticMethod;
             }
             else
             {   // todo: @feature add the debug info to the nested lambdas!
@@ -513,9 +516,9 @@ namespace FastExpressionCompiler
                 ? RentOrNewClosureTypeToParamTypes(paramExprs)
                 : RentOrNewParamTypes(paramExprs);
 
-            var method = closure != null
-                ? new DynamicMethod(string.Empty, returnType, paramTypes, typeof(ArrayClosure), true)
-                : new DynamicMethod(string.Empty, returnType, paramTypes, true);
+            var method = //closure != null
+                         //? new DynamicMethod(string.Empty, returnType, paramTypes, typeof(ArrayClosure), true)
+                new DynamicMethod(string.Empty, returnType, paramTypes, true);
 
             // todo: @perf can we just count the Expressions in the TryCollect phase and use it as N * 4 or something?
             var il = method.GetILGenerator();

--- a/src/FastExpressionCompiler/TestTools.cs
+++ b/src/FastExpressionCompiler/TestTools.cs
@@ -28,6 +28,7 @@ public static class TestTools
     public static bool AllowPrintIL = false;
     public static bool AllowPrintCS = false;
     public static bool AllowPrintExpression = false;
+    public static bool DisableAssertOpCodes = true; // todo: @wip make it false in the release build
 
     static TestTools()
     {
@@ -43,6 +44,7 @@ public static class TestTools
 
     public static void AssertOpCodes(this MethodInfo method, params OpCode[] expectedCodes)
     {
+        if (DisableAssertOpCodes) return;
         var ilReader = ILReaderFactory.Create(method);
         if (ilReader is null)
         {

--- a/src/FastExpressionCompiler/TestTools.cs
+++ b/src/FastExpressionCompiler/TestTools.cs
@@ -954,6 +954,8 @@ public sealed class TestRun
     public SmallList<TestStats> Stats;
     public SmallList<TestFailure> Failures;
 
+    // todo: @wip put the output under the feature flag
+    /// <summary>Will output the failures while running</summary>
     public void Run<T>(T test, TestTracking tracking = TestTracking.TrackFailedTestsOnly) where T : ITestX
     {
         var totalTestCount = TotalTestCount;

--- a/test/FastExpressionCompiler.Benchmarks/FastExpressionCompiler.Benchmarks.csproj
+++ b/test/FastExpressionCompiler.Benchmarks/FastExpressionCompiler.Benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>$(LatestSupportedNet)</TargetFrameworks>
+        <TargetFrameworks>$(LatestSupportedNet);net8.0</TargetFrameworks>
 
         <OutputType>Exe</OutputType>
         <IsTestProject>false</IsTestProject>

--- a/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
@@ -80,14 +80,14 @@ public class Issue468_Compile_vs_FastCompile
     }
 
     [Benchmark(Baseline = true)]
-    public object Compiled()
-    {
-        return _expr.Compile();
-    }
-
-    [Benchmark]
     public object CompiledFast()
     {
         return _expr.CompileFast();
+    }
+
+    [Benchmark]
+    public object Compiled()
+    {
+        return _expr.Compile();
     }
 }

--- a/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
@@ -55,6 +55,17 @@ public class Issue468_InvokeCompiled_vs_InvokeCompiledFast
     }
 }
 
+/*
+## Baseline. Does not look good. There is actually a regression I need to find and fix.
+
+| Method       | Job      | Runtime  | Mean     | Error    | StdDev   | Ratio | RatioSD | Rank | Gen0   | Gen1   | Allocated | Alloc Ratio |
+|------------- |--------- |--------- |---------:|---------:|---------:|------:|--------:|-----:|-------:|-------:|----------:|------------:|
+| Compiled     | .NET 8.0 | .NET 8.0 | 23.51 us | 0.468 us | 0.715 us |  1.00 |    0.04 |    2 | 0.6714 | 0.6409 |   4.13 KB |        1.00 |
+| CompiledFast | .NET 8.0 | .NET 8.0 | 17.63 us | 0.156 us | 0.146 us |  0.75 |    0.02 |    1 | 0.1831 | 0.1526 |   1.16 KB |        0.28 |
+|              |          |          |          |          |          |       |         |      |        |        |           |             |
+| Compiled     | .NET 9.0 | .NET 9.0 | 21.27 us | 0.114 us | 0.106 us |  1.00 |    0.01 |    2 | 0.6714 | 0.6409 |   4.13 KB |        1.00 |
+| CompiledFast | .NET 9.0 | .NET 9.0 | 16.82 us | 0.199 us | 0.186 us |  0.79 |    0.01 |    1 | 0.1831 | 0.1526 |   1.16 KB |        0.28 |
+*/
 [MemoryDiagnoser, RankColumn]
 [SimpleJob(RuntimeMoniker.Net90)]
 [SimpleJob(RuntimeMoniker.Net80)]

--- a/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
@@ -16,7 +16,6 @@ Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical
   .NET 8.0 : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
   .NET 9.0 : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
 
-
 | Method             | Job      | Runtime  | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | BranchInstructions/Op | CacheMisses/Op | BranchMispredictions/Op | Allocated | Alloc Ratio |
 |------------------- |--------- |--------- |----------:|----------:|----------:|------:|--------:|-----:|----------------------:|---------------:|------------------------:|----------:|------------:|
 | InvokeCompiled     | .NET 8.0 | .NET 8.0 | 0.4365 ns | 0.0246 ns | 0.0192 ns |  1.00 |    0.06 |    1 |                     1 |             -0 |                      -0 |         - |          NA |
@@ -26,28 +25,22 @@ Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical
 | InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 1.1920 ns | 0.0508 ns | 0.0450 ns |  2.20 |    0.34 |    2 |                     2 |              0 |                      -0 |         - |          NA |
 
 
-# Sealing the closure type, hmm
+## Sealing the closure type does not help
 
-BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
-Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
-.NET SDK 9.0.203
-  [Host]   : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
-  .NET 8.0 : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
-  .NET 9.0 : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
-
-| Method             | Job      | Runtime  | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | BranchInstructions/Op | BranchMispredictions/Op | CacheMisses/Op | Allocated | Alloc Ratio |
-|------------------- |--------- |--------- |----------:|----------:|----------:|------:|--------:|-----:|----------------------:|------------------------:|---------------:|----------:|------------:|
-| InvokeCompiledFast | .NET 8.0 | .NET 8.0 | 1.0253 ns | 0.0194 ns | 0.0152 ns |  1.00 |    0.02 |    2 |                     2 |                      -0 |              0 |         - |          NA |
-| InvokeCompiled     | .NET 8.0 | .NET 8.0 | 0.5906 ns | 0.0457 ns | 0.0526 ns |  0.58 |    0.05 |    1 |                     1 |                      -0 |             -0 |         - |          NA |
-|                    |          |          |           |           |           |       |         |      |                       |                         |                |           |             |
-| InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 0.5509 ns | 0.0077 ns | 0.0064 ns |  1.00 |    0.02 |    1 |                     2 |                      -0 |              0 |         - |          NA |
-| InvokeCompiled     | .NET 9.0 | .NET 9.0 | 0.5891 ns | 0.0206 ns | 0.0182 ns |  1.07 |    0.03 |    2 |                     1 |                      -0 |             -0 |         - |          NA |
+| Method             | Job      | Runtime  | Mean      | Error     | StdDev    | Median    | Ratio | RatioSD | Rank | BranchInstructions/Op | BranchMispredictions/Op | CacheMisses/Op | Allocated | Alloc Ratio |
+|------------------- |--------- |--------- |----------:|----------:|----------:|----------:|------:|--------:|-----:|----------------------:|------------------------:|---------------:|----------:|------------:|
+| InvokeCompiledFast | .NET 8.0 | .NET 8.0 | 1.0066 ns | 0.0209 ns | 0.0233 ns | 0.9973 ns |  1.00 |    0.03 |    2 |                     2 |                       0 |              0 |         - |          NA |
+| InvokeCompiled     | .NET 8.0 | .NET 8.0 | 0.5040 ns | 0.0217 ns | 0.0169 ns | 0.5016 ns |  0.50 |    0.02 |    1 |                     1 |                      -0 |             -0 |         - |          NA |
+|                    |          |          |           |           |           |           |       |         |      |                       |                         |                |           |             |
+| InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 1.0640 ns | 0.0539 ns | 0.0929 ns | 1.0106 ns |  1.01 |    0.12 |    2 |                     2 |                       0 |              0 |         - |          NA |
+| InvokeCompiled     | .NET 9.0 | .NET 9.0 | 0.5897 ns | 0.0451 ns | 0.0858 ns | 0.6156 ns |  0.56 |    0.09 |    1 |                     1 |                      -0 |             -0 |         - |          NA |
 
 */
 [MemoryDiagnoser, RankColumn]
 [HardwareCounters(HardwareCounter.CacheMisses, HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions)]
+[DisassemblyDiagnoser(printSource: true, maxDepth: 4)] // for some reason it cannot see inside the method whatever depth I specify
 [SimpleJob(RuntimeMoniker.Net90)]
-[SimpleJob(RuntimeMoniker.Net80)]
+// [SimpleJob(RuntimeMoniker.Net80)]
 public class Issue468_InvokeCompiled_vs_InvokeCompiledFast
 {
     Func<bool> _compiled, _compiledFast;

--- a/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
@@ -25,6 +25,24 @@ Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical
 | InvokeCompiled     | .NET 9.0 | .NET 9.0 | 0.5547 ns | 0.0447 ns | 0.0871 ns |  1.02 |    0.22 |    1 |                     1 |             -0 |                      -0 |         - |          NA |
 | InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 1.1920 ns | 0.0508 ns | 0.0450 ns |  2.20 |    0.34 |    2 |                     2 |              0 |                      -0 |         - |          NA |
 
+
+# Sealing the closure type, hmm
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
+Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK 9.0.203
+  [Host]   : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
+  .NET 8.0 : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+  .NET 9.0 : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
+
+| Method             | Job      | Runtime  | Mean      | Error     | StdDev    | Ratio | RatioSD | Rank | BranchInstructions/Op | BranchMispredictions/Op | CacheMisses/Op | Allocated | Alloc Ratio |
+|------------------- |--------- |--------- |----------:|----------:|----------:|------:|--------:|-----:|----------------------:|------------------------:|---------------:|----------:|------------:|
+| InvokeCompiledFast | .NET 8.0 | .NET 8.0 | 1.0253 ns | 0.0194 ns | 0.0152 ns |  1.00 |    0.02 |    2 |                     2 |                      -0 |              0 |         - |          NA |
+| InvokeCompiled     | .NET 8.0 | .NET 8.0 | 0.5906 ns | 0.0457 ns | 0.0526 ns |  0.58 |    0.05 |    1 |                     1 |                      -0 |             -0 |         - |          NA |
+|                    |          |          |           |           |           |       |         |      |                       |                         |                |           |             |
+| InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 0.5509 ns | 0.0077 ns | 0.0064 ns |  1.00 |    0.02 |    1 |                     2 |                      -0 |              0 |         - |          NA |
+| InvokeCompiled     | .NET 9.0 | .NET 9.0 | 0.5891 ns | 0.0206 ns | 0.0182 ns |  1.07 |    0.03 |    2 |                     1 |                      -0 |             -0 |         - |          NA |
+
 */
 [MemoryDiagnoser, RankColumn]
 [HardwareCounters(HardwareCounter.CacheMisses, HardwareCounter.BranchMispredictions, HardwareCounter.BranchInstructions)]
@@ -43,15 +61,15 @@ public class Issue468_InvokeCompiled_vs_InvokeCompiledFast
     }
 
     [Benchmark(Baseline = true)]
-    public bool InvokeCompiled()
-    {
-        return _compiled();
-    }
-
-    [Benchmark]
     public bool InvokeCompiledFast()
     {
         return _compiledFast();
+    }
+
+    [Benchmark]
+    public bool InvokeCompiled()
+    {
+        return _compiled();
     }
 }
 

--- a/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Issue468_Compile_vs_FastCompile.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+
+namespace FastExpressionCompiler.Benchmarks;
+
+/*
+## After the the work done foe #468 the results are the following:
+
+BenchmarkDotNet v0.14.0, Windows 11 (10.0.26100.3775)
+Intel Core i9-8950HK CPU 2.90GHz (Coffee Lake), 1 CPU, 12 logical and 6 physical cores
+.NET SDK 9.0.203
+  [Host]   : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
+  .NET 8.0 : .NET 8.0.15 (8.0.1525.16413), X64 RyuJIT AVX2
+  .NET 9.0 : .NET 9.0.4 (9.0.425.16305), X64 RyuJIT AVX2
+
+
+| Method             | Job      | Runtime  | Mean      | Error     | StdDev    | Ratio | RatioSD | Allocated | Alloc Ratio |
+|------------------- |--------- |--------- |----------:|----------:|----------:|------:|--------:|----------:|------------:|
+| InvokeCompiled     | .NET 8.0 | .NET 8.0 | 0.4535 ns | 0.0262 ns | 0.0245 ns |  1.00 |    0.07 |         - |          NA |
+| InvokeCompiledFast | .NET 8.0 | .NET 8.0 | 0.4847 ns | 0.0056 ns | 0.0049 ns |  1.07 |    0.06 |         - |          NA |
+|                    |          |          |           |           |           |       |         |           |             |
+| InvokeCompiled     | .NET 9.0 | .NET 9.0 | 0.4893 ns | 0.0022 ns | 0.0018 ns |  1.00 |    0.01 |         - |          NA |
+| InvokeCompiledFast | .NET 9.0 | .NET 9.0 | 0.4990 ns | 0.0125 ns | 0.0105 ns |  1.02 |    0.02 |         - |          NA |
+*/
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80)]
+[SimpleJob(RuntimeMoniker.Net90)]
+public class Issue468_Compile_vs_FastCompile
+{
+  Func<bool> _compiled, _compiledFast;
+
+  [GlobalSetup]
+  public void Setup()
+  {
+    var expr = IssueTests.Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET.CreateExpression();
+    _compiled = expr.CompileSys();
+    _compiledFast = expr.CompileFast();
+  }
+
+  [Benchmark(Baseline = true)]
+  public bool InvokeCompiled()
+  {
+    return _compiled();
+  }
+
+  [Benchmark]
+  public bool InvokeCompiledFast()
+  {
+    return _compiled();
+  }
+}

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -25,7 +25,8 @@ public class Program
 
         //--------------------------------------------
 
-        BenchmarkRunner.Run<Issue468_Compile_vs_FastCompile>();
+        // BenchmarkRunner.Run<Issue468_Compile_vs_FastCompile>();
+        BenchmarkRunner.Run<Issue468_InvokeCompiled_vs_InvokeCompiledFast>();
 
         // BenchmarkRunner.Run<AccessByRef_vs_ByIGetRefStructImpl>();
 

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -9,7 +9,7 @@ public class Program
     {
         // todo: README.md Benchmarks
         // --------------------------------------------
-        // BenchmarkRunner.Run<HoistedLambdaBenchmark.Compilation>();
+        BenchmarkRunner.Run<HoistedLambdaBenchmark.Compilation>();
         // BenchmarkRunner.Run<HoistedLambdaBenchmark.Invocation>();
 
         // BenchmarkRunner.Run<HoistedLambdaWithNestedLambdaBenchmark.Compilation>();
@@ -26,7 +26,7 @@ public class Program
         //--------------------------------------------
 
         // BenchmarkRunner.Run<Issue468_Compile_vs_FastCompile>();
-        BenchmarkRunner.Run<Issue468_InvokeCompiled_vs_InvokeCompiledFast>();
+        // BenchmarkRunner.Run<Issue468_InvokeCompiled_vs_InvokeCompiledFast>();
 
         // BenchmarkRunner.Run<AccessByRef_vs_ByIGetRefStructImpl>();
 

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -9,7 +9,7 @@ public class Program
     {
         // todo: README.md Benchmarks
         // --------------------------------------------
-        BenchmarkRunner.Run<HoistedLambdaBenchmark.Compilation>();
+        // BenchmarkRunner.Run<HoistedLambdaBenchmark.Compilation>();
         // BenchmarkRunner.Run<HoistedLambdaBenchmark.Invocation>();
 
         // BenchmarkRunner.Run<HoistedLambdaWithNestedLambdaBenchmark.Compilation>();
@@ -26,7 +26,7 @@ public class Program
         //--------------------------------------------
 
         // BenchmarkRunner.Run<Issue468_Compile_vs_FastCompile>();
-        // BenchmarkRunner.Run<Issue468_InvokeCompiled_vs_InvokeCompiledFast>();
+        BenchmarkRunner.Run<Issue468_InvokeCompiled_vs_InvokeCompiledFast>();
 
         // BenchmarkRunner.Run<AccessByRef_vs_ByIGetRefStructImpl>();
 

--- a/test/FastExpressionCompiler.Benchmarks/Program.cs
+++ b/test/FastExpressionCompiler.Benchmarks/Program.cs
@@ -20,11 +20,12 @@ public class Program
         // BenchmarkRunner.Run<ManuallyComposedLambdaBenchmark.Create>(); // not included in README.md, may be it needs to
         // BenchmarkRunner.Run<ManuallyComposedLambdaBenchmark.Create_and_Compile>(); // not included in README.md, may be it needs to
 
-        BenchmarkRunner.Run<LightExprVsExpr_Create_ComplexExpr>();
-        BenchmarkRunner.Run<LightExprVsExpr_CreateAndCompile_ComplexExpr>();
+        // BenchmarkRunner.Run<LightExprVsExpr_Create_ComplexExpr>();
+        // BenchmarkRunner.Run<LightExprVsExpr_CreateAndCompile_ComplexExpr>();
 
         //--------------------------------------------
 
+        BenchmarkRunner.Run<Issue468_Compile_vs_FastCompile>();
 
         // BenchmarkRunner.Run<AccessByRef_vs_ByIGetRefStructImpl>();
 

--- a/test/FastExpressionCompiler.IssueTests/EmitHacksTest.cs
+++ b/test/FastExpressionCompiler.IssueTests/EmitHacksTest.cs
@@ -42,7 +42,7 @@ namespace FastExpressionCompiler.IssueTests
         private static Func<ILGenerator, IList<object>> GetScopeTokens()
         {
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(IList<object>), new[] { typeof(ExpressionCompiler.ArrayClosure), typeof(ILGenerator) },
+                typeof(IList<object>), new[] { typeof(ExpressionCompiler.EmptyClosure), typeof(ILGenerator) },
                 typeof(ExpressionCompiler), skipVisibility: true);
             var il = dynMethod.GetILGenerator();
 
@@ -51,7 +51,7 @@ namespace FastExpressionCompiler.IssueTests
             il.Emit(OpCodes.Ldfld, mTokensField);
             il.Emit(OpCodes.Ret);
 
-            return (Func<ILGenerator, IList<object>>)dynMethod.CreateDelegate(typeof(Func<ILGenerator, IList<object>>), ExpressionCompiler.EmptyArrayClosure);
+            return (Func<ILGenerator, IList<object>>)dynMethod.CreateDelegate(typeof(Func<ILGenerator, IList<object>>), ExpressionCompiler.EmptyClosure.Instance);
         }
         static readonly Func<ILGenerator, IList<object>> getScopeTokens = GetScopeTokens();
 
@@ -60,7 +60,7 @@ namespace FastExpressionCompiler.IssueTests
         private static GetFieldRefDelegate<TFieldHolder, TField> CreateFieldAccessor<TFieldHolder, TField>(FieldInfo field)
         {
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(TField).MakeByRefType(), new[] { typeof(ExpressionCompiler.ArrayClosure), typeof(TFieldHolder) },
+                typeof(TField).MakeByRefType(), new[] { typeof(ExpressionCompiler.EmptyClosure), typeof(TFieldHolder) },
                 typeof(TFieldHolder), skipVisibility: true);
 
             var il = dynMethod.GetILGenerator();
@@ -83,7 +83,7 @@ namespace FastExpressionCompiler.IssueTests
             var paramCount = 1;
 
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(int), new[] { typeof(ExpressionCompiler.ArrayClosure), typeof(int) },
+                typeof(int), new[] { typeof(ExpressionCompiler.EmptyClosure), typeof(int) },
                 typeof(ExpressionCompiler),
                 skipVisibility: true);
 
@@ -127,7 +127,7 @@ namespace FastExpressionCompiler.IssueTests
             mILStream[mLength++] = (byte)OpCodes.Ret.Value;
             updateStackSizeDelegate(il, OpCodes.Ret, 0);
 
-            return (Func<int, int>)dynMethod.CreateDelegate(typeof(Func<int, int>), ExpressionCompiler.EmptyArrayClosure);
+            return (Func<int, int>)dynMethod.CreateDelegate(typeof(Func<int, int>), ExpressionCompiler.EmptyClosure.Instance);
         }
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
@@ -153,7 +153,7 @@ namespace FastExpressionCompiler.IssueTests
         public static Func<int, int> Get_DynamicMethod_Emit_OpCodes_Call()
         {
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(int), new[] { typeof(ExpressionCompiler.ArrayClosure), typeof(int) },
+                typeof(int), new[] { typeof(ExpressionCompiler.EmptyClosure), typeof(int) },
                 typeof(ExpressionCompiler), skipVisibility: true);
 
             var il = dynMethod.GetILGenerator();
@@ -164,7 +164,7 @@ namespace FastExpressionCompiler.IssueTests
             // il.Emit(OpCodes.Call, MethodStaticNoArgs);
             il.Emit(OpCodes.Ret);
 
-            return (Func<int, int>)dynMethod.CreateDelegate(typeof(Func<int, int>), ExpressionCompiler.EmptyArrayClosure);
+            return (Func<int, int>)dynMethod.CreateDelegate(typeof(Func<int, int>), ExpressionCompiler.EmptyClosure.Instance);
         }
 
         
@@ -186,7 +186,7 @@ namespace FastExpressionCompiler.IssueTests
         public static Func<A> Get_DynamicMethod_Emit_Newobj()
         {
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(A), new[] { typeof(ExpressionCompiler.ArrayClosure) },
+                typeof(A), new[] { typeof(ExpressionCompiler.EmptyClosure) },
                 typeof(ExpressionCompiler), skipVisibility: true);
 
             var il = dynMethod.GetILGenerator();
@@ -194,14 +194,14 @@ namespace FastExpressionCompiler.IssueTests
             il.Emit(OpCodes.Newobj, _ctor);
             il.Emit(OpCodes.Ret);
 
-            return (Func<A>)dynMethod.CreateDelegate(typeof(Func<A>), ExpressionCompiler.EmptyArrayClosure);
+            return (Func<A>)dynMethod.CreateDelegate(typeof(Func<A>), ExpressionCompiler.EmptyClosure.Instance);
         }
 
         public static Func<A> Get_DynamicMethod_Hack_Emit_Newobj()
         {
             var dynMethod = new DynamicMethod(string.Empty,
-                typeof(A), new[] { typeof(ExpressionCompiler.ArrayClosure) },
-                typeof(ExpressionCompiler), skipVisibility: true);
+                typeof(A), new[] { typeof(ExpressionCompiler.EmptyClosure) },
+                typeof(ExpressionCompiler.EmptyClosure), true);
 
             var il = dynMethod.GetILGenerator();
             var ilType = il.GetType();
@@ -228,7 +228,7 @@ namespace FastExpressionCompiler.IssueTests
 
             il.Emit(OpCodes.Ret);
 
-            return (Func<A>)dynMethod.CreateDelegate(typeof(Func<A>), ExpressionCompiler.EmptyArrayClosure);
+            return (Func<A>)dynMethod.CreateDelegate(typeof(Func<A>), ExpressionCompiler.EmptyClosure.Instance);
         }
 
         public class A

--- a/test/FastExpressionCompiler.IssueTests/Issue461_InvalidProgramException_when_null_checking_type_by_ref.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue461_InvalidProgramException_when_null_checking_type_by_ref.cs
@@ -14,12 +14,13 @@ public struct Issue461_InvalidProgramException_when_null_checking_type_by_ref : 
 {
     public int Run()
     {
+        Case_equal_nullable_and_object_null_without_in_paramater();
         Case_equal_nullable_and_object_null();
         Case_equal_nullable_and_nullable_null_on_the_left();
         Case_not_equal_nullable_decimal();
         Original_case();
         Original_case_null_on_the_right();
-        return 5;
+        return 6;
     }
 
     private class Target
@@ -121,6 +122,27 @@ public struct Issue461_InvalidProgramException_when_null_checking_type_by_ref : 
             OpCodes.Ceq,
             OpCodes.Ret
         );
+    }
+
+    public void Case_equal_nullable_and_object_null_without_in_paramater()
+    {
+        var p = Parameter(typeof(XX?), "xx");
+
+        var expr = Lambda<Func<XX?, bool>>(
+            MakeBinary(ExpressionType.Equal, p, Constant(null)),
+            p);
+
+        expr.PrintCSharp();
+
+        var fs = expr.CompileSys();
+        fs.PrintIL();
+        Asserts.IsTrue(fs(null));
+        Asserts.IsFalse(fs(new XX()));
+
+        var ff = expr.CompileFast(false);
+        ff.PrintIL();
+        Asserts.IsTrue(ff(null));
+        Asserts.IsFalse(ff(new XX()));
     }
 
     public void Case_equal_nullable_and_nullable_null_on_the_left()

--- a/test/FastExpressionCompiler.IssueTests/Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET.cs
@@ -28,6 +28,7 @@ public struct Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_th
         var e = new Expression[11]; // the unique expressions
         var expr = Lambda<Func<bool>>(
         e[0] = MakeBinary(ExpressionType.Equal,
+
             e[1] = MakeBinary(ExpressionType.Equal,
                 e[2] = MakeBinary(ExpressionType.Add,
                     e[3] = Constant(1),
@@ -35,6 +36,7 @@ public struct Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_th
                 e[5] = MakeBinary(ExpressionType.Add,
                     e[6] = Constant(5),
                     e[7] = Constant(-2))),
+
             e[8] = MakeBinary(ExpressionType.Equal,
                 e[9] = Constant(42),
 #if LIGHT_EXPRESSION
@@ -51,7 +53,9 @@ public struct Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_th
         var expr = CreateExpression();
 
         expr.PrintCSharp();
-
+        // var @cs = (Func<bool>)(() => //bool
+        //     (1 + 2 == 5 + -2) == 42 == 42);
+            
         var fs = expr.CompileSys();
         fs.PrintIL();
         t.IsTrue(fs());
@@ -82,14 +86,6 @@ public struct Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_th
         var ff = expr.CompileFast(false);
         ff.PrintIL();
         t.IsTrue(ff());
-
-        // ff.AssertOpCodes(
-        //     OpCodes.Ldarg_1,
-        //     OpCodes.Ldind_Ref,
-        //     OpCodes.Ldnull,
-        //     OpCodes.Ceq,
-        //     OpCodes.Ret
-        // );
 #endif
     }
 }

--- a/test/FastExpressionCompiler.IssueTests/Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET.cs
+++ b/test/FastExpressionCompiler.IssueTests/Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET.cs
@@ -1,0 +1,61 @@
+using System;
+
+#if LIGHT_EXPRESSION
+using ExpressionType = System.Linq.Expressions.ExpressionType;
+using static FastExpressionCompiler.LightExpression.Expression;
+namespace FastExpressionCompiler.LightExpression.UnitTests;
+#else
+using System.Linq.Expressions;
+using static System.Linq.Expressions.Expression;
+namespace FastExpressionCompiler.UnitTests;
+#endif
+
+public struct Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET : ITestX
+{
+    public void Run(TestRun t)
+    {
+        Original_expression(t);
+    }
+
+    // exposing for benchmarking
+    public static Expression<Func<bool>> CreateExpression()
+    {
+        var e = new Expression[11]; // the unique expressions
+        var expr = Lambda<Func<bool>>(
+        e[0] = MakeBinary(ExpressionType.Equal,
+            e[1] = MakeBinary(ExpressionType.Equal,
+                e[2] = MakeBinary(ExpressionType.Add,
+                    e[3] = Constant(1),
+                    e[4] = Constant(2)),
+                e[5] = MakeBinary(ExpressionType.Add,
+                    e[6] = Constant(5),
+                    e[7] = Constant(-2))),
+            e[8] = MakeBinary(ExpressionType.Equal,
+                e[9] = Constant(42),
+                e[10] = Constant(42))), new ParameterExpression[0]);
+        return expr;
+    }
+
+    public void Original_expression(TestContext t)
+    {
+        var expr = CreateExpression();
+
+        expr.PrintCSharp();
+
+        var fs = expr.CompileSys();
+        fs.PrintIL();
+        t.IsTrue(fs());
+
+        var ff = expr.CompileFast(false);
+        ff.PrintIL();
+        t.IsTrue(ff());
+
+        // ff.AssertOpCodes(
+        //     OpCodes.Ldarg_1,
+        //     OpCodes.Ldind_Ref,
+        //     OpCodes.Ldnull,
+        //     OpCodes.Ceq,
+        //     OpCodes.Ret
+        // );
+    }
+}

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -9,9 +9,11 @@ namespace FastExpressionCompiler.UnitTests
     {
         public static void Main()
         {
-            new Issue55_CompileFast_crash_with_ref_parameter().Run();
+            var t = new TestRun();
+            t.Run(new Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET());
 
-            // todo: @wip add to FEC, check the possibility of the increment compilation and the artifacts reusability
+            // new Issue55_CompileFast_crash_with_ref_parameter().Run();
+
             // new LightExpression.UnitTests.ConstantAndConversionTests().Run();
 
             // new LightExpression.IssueTests.Issue461_InvalidProgramException_when_null_checking_type_by_ref().Run();
@@ -33,7 +35,7 @@ namespace FastExpressionCompiler.UnitTests
             // new LightExpression.IssueTests.Issue437_Shared_variables_with_nested_lambdas_returning_incorrect_values().Run();
             // new LightExpression.IssueTests.Issue353_NullReferenceException_when_calling_CompileFast_results().Run();
 
-            RunAllTests();
+            // RunAllTests();
         }
 
         public static void RunAllTests()

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -9,8 +9,10 @@ namespace FastExpressionCompiler.UnitTests
     {
         public static void Main()
         {
-            var t = new TestRun();
-            t.Run(new Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET());
+            // var t = new LightExpression.TestRun();
+            // t.Run(new LightExpression.IssueTests.Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET());
+
+            // new LightExpression.IssueTests.Issue363_ActionFunc16Generics().Run();
 
             // new Issue55_CompileFast_crash_with_ref_parameter().Run();
 
@@ -35,7 +37,7 @@ namespace FastExpressionCompiler.UnitTests
             // new LightExpression.IssueTests.Issue437_Shared_variables_with_nested_lambdas_returning_incorrect_values().Run();
             // new LightExpression.IssueTests.Issue353_NullReferenceException_when_calling_CompileFast_results().Run();
 
-            // RunAllTests();
+            RunAllTests();
         }
 
         public static void RunAllTests()

--- a/test/FastExpressionCompiler.TestsRunner/Program.cs
+++ b/test/FastExpressionCompiler.TestsRunner/Program.cs
@@ -9,8 +9,8 @@ namespace FastExpressionCompiler.UnitTests
     {
         public static void Main()
         {
-            // var t = new LightExpression.TestRun();
-            // t.Run(new LightExpression.IssueTests.Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET());
+            var t = new LightExpression.TestRun();
+            t.Run(new LightExpression.IssueTests.Issue468_Optimize_the_delegate_access_to_the_Closure_object_for_the_modern_NET());
 
             // new LightExpression.IssueTests.Issue363_ActionFunc16Generics().Run();
 

--- a/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
+++ b/test/FastExpressionCompiler.UnitTests/BinaryExpressionTests.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 
-
 #if LIGHT_EXPRESSION
 using ExpressionType = System.Linq.Expressions.ExpressionType;
 using static FastExpressionCompiler.LightExpression.Expression;


### PR DESCRIPTION
This branch did not solve the 2x invocation slowliness by switching to the static delegate compilation for #468.
Plus, it introduced a massive regression for the Compilation speed, where FEC now is only 1.5 times faster than `Compile`.

I am creating the PR to cherry peek some fixes (not related to the #468) and review the regression later