### PR TITLE
Fix unsigned int to floating point number conversion

### DIFF
--- a/src/FastExpressionCompiler/FastExpressionCompiler.cs
+++ b/src/FastExpressionCompiler/FastExpressionCompiler.cs
@@ -3508,10 +3508,12 @@ namespace FastExpressionCompiler
                         il.Demit(isChecked ? OpCodes.Conv_Ovf_I8 : OpCodes.Conv_I8);
                         break;
                     case TypeCode.Double:
+                        if (sourceType.IsUnsigned())
+                            il.Demit(OpCodes.Conv_R_Un);
                         il.Demit(OpCodes.Conv_R8);
                         break;
                     case TypeCode.Single:
-                        if (sourceType == typeof(uint))
+                        if (sourceType.IsUnsigned())
                             il.Demit(OpCodes.Conv_R_Un);
                         il.Demit(OpCodes.Conv_R4);
                         break;


### PR DESCRIPTION
Simplest repro:

Convert(Constant(uint.MaxValue), typeof(double))

Previously it would return -1, since the conv.r.un instruction wasn't used. It was only applied to uint->float, but not for double or any other integer type. Only uint/ulong was problematic, but the test covers all integer types.
(nuint/nint are not supported by Linq.Expression conversions)